### PR TITLE
added calls to force https urls

### DIFF
--- a/app/templates/country_list.html
+++ b/app/templates/country_list.html
@@ -19,7 +19,7 @@
                 </div>
             </div>
         {% endfor %}
-        <script src="{{url_for('static', path='js/map.js')}}"></script>
+        <script src="{{url_for('static', path='js/map.js', _external=True, _scheme='https')}}"></script>
         <script>
           let countries = {{countries|tojson}};
           countries.forEach(draw_map);

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -36,7 +36,7 @@
           <script>
             let country_data = {{countries|tojson}};
           </script>
-            <script src="{{url_for('static', path='js/world.js')}}" type="module">
+            <script src="{{url_for('static', path='js/world.js', _external=True, _scheme='https')}}" type="module">
           </script>
     </div>
   </div>


### PR DESCRIPTION
Added `_external=True` and `_scheme='https'` to the `url_for()` calls to force HTTPS URLs. This ensures the scripts are always loaded over HTTPS regardless of the server configuration.

