### PR TITLE
Add pagination to HTML views

### DIFF
--- a/app/crud/author.py
+++ b/app/crud/author.py
@@ -187,6 +187,18 @@ class Author:
                    SKIP $skip
                    LIMIT $limit;
                    """
-        records, _, _ = db.execute_query(query, skip=skip, limit=limit)
+        records, summary, keys = db.execute_query(query,
+                                                  skip=skip,
+                                                  limit=limit)
 
         return [record.data() for record in records]
+
+    @connect_to_db
+    def count_authors(self, db: Driver) -> int:
+        """Count the number of authors"""
+        query = """MATCH (a:Author)
+                RETURN COUNT(a) as count
+                """
+        records, _, _ = db.execute_query(query)
+
+        return [record.data() for record in records][0]['count']

--- a/app/crud/author.py
+++ b/app/crud/author.py
@@ -182,7 +182,7 @@ class Author:
         query = """MATCH (a:Author)
                    OPTIONAL MATCH (a)-[:member_of]->(p:Partner)
                    OPTIONAL MATCH (a)-[:member_of]->(u:Workstream)
-                   RETURN a.first_name as first_name, a.last_name as last_name, a.uuid as uuid, a.orcid as orcid, collect(p) as affiliations, collect(u) as workstreams
+                   RETURN a.first_name as first_name, a.last_name as last_name, a.uuid as uuid, a.orcid as orcid, collect(DISTINCT p) as affiliations, collect(DISTINCT u) as workstreams
                    ORDER BY last_name
                    SKIP $skip
                    LIMIT $limit;

--- a/app/crud/author.py
+++ b/app/crud/author.py
@@ -62,8 +62,8 @@ class Author:
             OPTIONAL MATCH (a)-[:member_of]->(u:Workstream)
             RETURN a.uuid as uuid, a.orcid as orcid,
                     a.first_name as first_name, a.last_name as last_name,
-                    collect(p) as affiliations,
-                    collect(u) as workstreams;"""
+                    collect(DISTINCT p) as affiliations,
+                    collect(DISTINCT u) as workstreams;"""
 
         author, _, _ = db.execute_query(author_query, uuid=id)
         results = author[0].data()

--- a/app/crud/author.py
+++ b/app/crud/author.py
@@ -69,11 +69,18 @@ class Author:
         results = author[0].data()
 
         collab_query = """
-            MATCH (a:Author)-[r:author_of]->(p:Output)<-[s:author_of]-(b:Author)
-            WHERE a.uuid = $uuid AND b.uuid <> $uuid
-            RETURN DISTINCT b.uuid as uuid, b.first_name as first_name, b.last_name as last_name, b.orcid as orcid
+            MATCH (a:Author)-[:author_of]->(z:Output)<-[:author_of]-(b:Author)
+            WHERE a.uuid = $uuid AND b.uuid <> $uuid AND z.result_type = $type
+            RETURN DISTINCT b.uuid as uuid,
+                   b.first_name as first_name,
+                   b.last_name as last_name,
+                   b.orcid as orcid,
+                   count(z) as num_colabs
+            ORDER BY num_colabs DESCENDING
             LIMIT 5"""
-        collab, _, _ = db.execute_query(collab_query, uuid=id)
+        collab, _, _ = db.execute_query(collab_query,
+                                        uuid=id,
+                                        type=result_type)
 
         results["collaborators"] = [x.data() for x in collab]
 

--- a/app/crud/output.py
+++ b/app/crud/output.py
@@ -75,7 +75,7 @@ class Output:
         """
         query = """
                 MATCH (a:Author)-[b:author_of]->(o:Article)
-                RETURN o.result_type as result_type, count(o) as count
+                RETURN o.result_type as result_type, count(DISTINCT o) as count
                 """
         records, summary, keys = db.execute_query(query)
         if len(records) > 0:
@@ -117,7 +117,7 @@ class Output:
             If result_type is invalid
         """
         query = """
-                MATCH (o:Article)
+                MATCH (o:Output)
                 WHERE o.result_type = $result_type
                 OPTIONAL MATCH (o)-[:REFERS_TO]->(c:Country)
                 CALL

--- a/app/schemas/author.py
+++ b/app/schemas/author.py
@@ -10,15 +10,24 @@ from .output import OutputListModel
 from .meta import Meta
 
 
-class AuthorListModel(AuthorBase):
+class AuthorColabModel(AuthorBase):
     """
-    Data model representing an academic author or contributor
-    with their associated metadata and relationships.
+    An academic author or contributor
+    with their collaborators, workstreams and affiliations
     """
-    affiliations: Optional[List[AffiliationModel]] = None
-    workstreams: Optional[List[WorkstreamBase]] = None
+    workstreams: List[WorkstreamBase] = None
+    affiliations: List[AffiliationModel] = None
 
 
-class AuthorModel(AuthorListModel):
+class AuthorListModel(BaseModel):
+    """
+    A list of authors
+    """
+    authors: List[AuthorColabModel]
+    meta: Meta
+
+
+class AuthorOutputModel(AuthorColabModel):
+    """An author with collaborators, workstreams, affiliations and outputs"""
     collaborators: List[AuthorBase] = None
     outputs: OutputListModel

--- a/app/schemas/meta.py
+++ b/app/schemas/meta.py
@@ -2,7 +2,7 @@ from typing import Dict, List, Optional
 
 from pydantic import BaseModel, Field
 
-class Count(BaseModel):
+class CountPublication(BaseModel):
     """Represents count of the outputs
     ```json
         {'total': 245684392,
@@ -20,6 +20,11 @@ class Count(BaseModel):
     other: int = 0
 
 
+class CountAuthor(BaseModel):
+    """Represents a count of the authors"""
+    total: int = 0
+
+
 class Meta(BaseModel):
     """
     Base data model representing an academic author or contributor
@@ -27,13 +32,7 @@ class Meta(BaseModel):
 
     ```json
     "count": {}
-    "db_response_time_ms": 929,
-    "page": 1,
-    "per_page": 25
     ```
 
     """
-    count: Count | None
-    db_response_time_ms: int
-    page: int
-    per_page: int
+    count: CountPublication | CountAuthor | None

--- a/app/templates/author.html
+++ b/app/templates/author.html
@@ -44,14 +44,24 @@
             {% if author.collaborators %}
             <div class="card">
                 <div class="card-body">
-                    <h5 class="card-title">Collaborators</h5>
+                    <h5 class="card-title">Top Collaborators for {{ type|title }}</h5>
                     <ul class="list-group list-group-flush">
                         {% for colab in author.collaborators %}
                         <li class="list-group-item"><a href="{{ url_for('author', id=colab.uuid) }}">{{ colab.first_name}} {{ colab.last_name }}</a>
-                            {% if colab.orcid %}
+                        {% if colab.orcid %}
                             <a href="{{ colab.orcid }}">
                             <img alt="ORCID logo" src="https://info.orcid.org/wp-content/uploads/2019/11/orcid_16x16.png" width="16" height="16" /></a>
                         {% endif %}</li>
+                        {% if colab.affiliations %}
+                            {% for value in colab.affiliations %}
+                                <span class="badge bg-primary">{{ value.name }}</span>
+                            {% endfor %}
+                        {% endif %}
+                        {% if colab.workstreams %}
+                            {% for value in colab.workstreams %}
+                                <span class="badge bg-secondary">{{ value.name }}</span>
+                            {% endfor %}
+                        {% endif %}
                         {% endfor %}
                     </ul>
                 </div></div>

--- a/app/templates/author.html
+++ b/app/templates/author.html
@@ -23,16 +23,16 @@
                     <!-- Affiliation -->
                     {% if author.affiliations %}
                         <h5 class="card-title">Affiliations</h5>
-                        {% for id, value in author.affiliations|dictsort %}
-                            <span class="badge bg-primary">{{ value }}</span>
+                        {% for affiliation in author.affiliations %}
+                            <span class="badge bg-primary">{{ affiliation.name }}</span>
                         {% endfor %}
                     {% endif %}
                 </div>
                 <div class="card-body">
                     {% if author.workstreams %}
                         <h5 class="card-title">Workstreams</h5>
-                        {% for id, value in author.workstreams|dictsort %}
-                            <span class="badge bg-secondary">{{ value }}</span>
+                        {% for workstream in author.workstreams %}
+                            <span class="badge bg-secondary">{{ workstream.name }}</span>
                         {% endfor %}
                     {% endif %}
                 </div>
@@ -60,8 +60,9 @@
         </div>
 
         <div class="row">
-                {% set outputs = author.outputs %}
-                {% include "output_list.j2" %}
+                {% set outputs = author.outputs.results %}
+                {% include 'output_list.j2' %}
+
         </div>
     </div>
 

--- a/app/templates/author.html
+++ b/app/templates/author.html
@@ -60,8 +60,9 @@
         </div>
 
         <div class="row">
-                {% set outputs = author.outputs.results %}
-                {% include 'output_list.j2' %}
+
+            {% set outputs = author.outputs.results %}
+            {% include 'output_list.j2' %}
 
         </div>
     </div>

--- a/app/templates/authors.html
+++ b/app/templates/authors.html
@@ -10,17 +10,42 @@
                 <img alt="ORCID logo" src="https://info.orcid.org/wp-content/uploads/2019/11/orcid_16x16.png" width="16" height="16" /></a>
             {% endif %}
             {% if author.affiliation %}
-                    {% for id, value in author.affiliation|dictsort %}
-                        <span class="badge bg-primary">{{ value }}</span>
+                    {% for value in author.affiliation %}
+                        <span class="badge bg-primary">{{ value.name }}</span>
                     {% endfor %}
             {% endif %}
             {% if author.workstreams %}
-                {% for id, value in author.workstreams|dictsort %}
-                    <span class="badge bg-secondary">{{ value }}</span>
+                {% for value in author.workstreams %}
+                    <span class="badge bg-secondary">{{ value.name }}</span>
                 {% endfor %}
             {% endif %}
         </div>
     </div>
     {% endfor %}
+
+    <div class="row">
+        <nav aria-label="Page navigation example">
+        <ul class="pagination justify-content-center">
+            {% if not skip == 0%}
+            <li class="page-item"><a class="page-link" href="?limit={{limit}}&skip={{skip - limit}}">Previous</a></li>
+            {% endif %}
+
+            {% if count %}
+            {% for page in range((count // limit) + 1) %}
+                {% set skipper = (page) * limit %}
+                {% if skipper == skip %}
+                    <li class="page-item"><a class="page-link active" href="?limit={{limit}}&skip={{skipper}}">{{ page + 1 }}</a></li>
+                {% else %}
+                    <li class="page-item"><a class="page-link" href="?limit={{limit}}&skip={{skipper}}">{{ page + 1 }}</a></li>
+                {% endif%}
+            {% endfor %}
+
+            {% if not skip >= count - limit %}
+            <li class="page-item"><a class="page-link" href="?limit={{limit}}&skip={{skip + limit}}">Next</a></li>
+            {% endif %}
+            {% endif %}
+        </ul>
+        </nav>
+    </div>
 
 {% endblock %}

--- a/app/templates/authors.html
+++ b/app/templates/authors.html
@@ -9,8 +9,8 @@
                 <a href="{{ author.orcid }}">
                 <img alt="ORCID logo" src="https://info.orcid.org/wp-content/uploads/2019/11/orcid_16x16.png" width="16" height="16" /></a>
             {% endif %}
-            {% if author.affiliation %}
-                    {% for value in author.affiliation %}
+            {% if author.affiliations %}
+                    {% for value in author.affiliations %}
                         <span class="badge bg-primary">{{ value.name }}</span>
                     {% endfor %}
             {% endif %}

--- a/app/templates/country.html
+++ b/app/templates/country.html
@@ -1,8 +1,13 @@
 {% extends "base.html" %}
 
 {% block content %}
-    <h1>{{ country.name }}</h1>
 
-    {% include 'output_list.j2' %}
+<div class="container" id="research_products">
+
+<h1>{{ country.name }}</h1>
+
+{% include 'output_list.j2' %}
+
+</div>
 
 {% endblock %}

--- a/app/templates/country_list.html
+++ b/app/templates/country_list.html
@@ -19,7 +19,7 @@
                 </div>
             </div>
         {% endfor %}
-        <script src="{{url_for('static', path='js/map.js', _external=True, _scheme='https')}}"></script>
+        <script src="{{url_for('static', path='js/map.js')}}"></script>
         <script>
           let countries = {{countries|tojson}};
           countries.forEach(draw_map);

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -36,7 +36,7 @@
           <script>
             let country_data = {{countries|tojson}};
           </script>
-            <script src="{{url_for('static', path='js/world.js', _external=True, _scheme='https')}}" type="module">
+            <script src="{{url_for('static', path='js/world.js')}}" type="module">
           </script>
     </div>
   </div>

--- a/app/templates/output_list.j2
+++ b/app/templates/output_list.j2
@@ -2,7 +2,7 @@
     <h5>Filter by result type: </h5>
     <div class="btn-group" id="filter_button" role="group" aria-label="Filter research type">
     {% for type in ['publication', 'dataset', 'software', 'other'] %}
-        <a href="{{ url_for('output_list') }}?type={{ type }}&limit={{limit}}&skip=0" class="btn btn-primary">
+        <a href="?type={{ type }}&limit={{limit}}&skip=0" class="btn btn-primary">
             {{type}}
             <span class="badge text-bg-secondary">{{count[type]|default(0)}}</span>
             </a>
@@ -56,6 +56,7 @@
         <li class="page-item"><a class="page-link" href="?type={{ type }}&limit={{limit}}&skip={{skip - limit}}">Previous</a></li>
         {% endif %}
 
+        {% if count[type] %}
         {% for page in range((count[type] // limit) + 1) %}
             {% set skipper = (page) * limit %}
             {% if skipper == skip %}
@@ -67,6 +68,7 @@
 
         {% if not skip >= count[type] - limit %}
         <li class="page-item"><a class="page-link" href="?type={{ type }}&limit={{limit}}&skip={{skip + limit}}">Next</a></li>
+        {% endif %}
         {% endif %}
     </ul>
     </nav>

--- a/app/templates/output_list.j2
+++ b/app/templates/output_list.j2
@@ -1,40 +1,16 @@
-
-
-<div class="row">
-    <h5>Filter by result type: </h5>
-    <div class="btn-group" id="filter_button" role="group" aria-label="Filter research type">
-        <a href="?type=publication" class="btn btn-primary">
-            publication
-            <span class="badge text-bg-secondary">{{count.publication}}</span>
-            </a>
-        <a href="?type=dataset" class="btn btn-primary">
-            dataset
-            <span class="badge text-bg-secondary">{{count.dataset}}</span>
-            </a>
-        <a href="?type=software" class="btn btn-primary">
-            tools
-            <span class="badge text-bg-secondary">{{count.software}}</span>
-            </a>
-        <a href="?type=other" class="btn btn-primary">
-            other
-            <span class="badge text-bg-secondary">{{count.other}}</span>
-            </a>
-    </div>
-</div>
-
 <div class="row">
     {% if outputs %}
         {% for output in outputs %}
-            <div class="card" id="{{output.outputs.uuid}}">
+            <div class="card" id="{{output.uuid}}">
                 <div class="card-body">
-                    <h5 class="card-title">{{ output.outputs.title }}
+                    <h5 class="card-title">{{ output.title }}
                         {% if output.countries %}
                             {% for country in output.countries %}
                             <a href="{{ url_for('country', id=country.id) }}" class="badge text-bg-danger">{{ country.name }}</a>
                             {% endfor %}
                         {% endif %}
-                        {% if output.outputs.result_type %}
-                            <span class="badge text-bg-secondary">{{ output.outputs.result_type }}</span>
+                        {% if output.result_type %}
+                            <span class="badge text-bg-secondary">{{ output.result_type }}</span>
                         {% endif %}
                     </h5>
                     {% for author in output.authors %}
@@ -43,11 +19,11 @@
                             <a href="{{ author.orcid }}"><img alt="ORCID logo" src="https://info.orcid.org/wp-content/uploads/2019/11/orcid_16x16.png" width="16" height="16" /></a>
                         {% endif %}</l>
                     {% endfor %}
-                    {% if output.outputs.publication_year %}({{ output.outputs.publication_year }}){% endif %}
-                    {% if output.outputs.journal %}{{ output.outputs.journal }}{% endif %}
+                    {% if output.publication_year %}({{ output.publication_year }}){% endif %}
+                    {% if output.journal %}{{ output.journal }}{% endif %}
                     <br>
-                    <a href="{{ url_for('output', id=output.outputs.uuid) }}" class="card-link">View Record</a>
-                    <a href="http://doi.org/{{ output.outputs.doi }}" class="card-link" target="_blank">View at Publisher</a>
+                    <a href="{{ url_for('output', id=output.uuid) }}" class="card-link">View Record</a>
+                    <a href="http://doi.org/{{ output.doi }}" class="card-link" target="_blank">View at Publisher</a>
                     </br>
                 </div>
             </div>
@@ -60,3 +36,4 @@
         </div>
     {% endif %}
 </div>
+

--- a/app/templates/output_list.j2
+++ b/app/templates/output_list.j2
@@ -50,7 +50,7 @@
 </div>
 
 <div class="row">
-    <nav aria-label="Page navigation example">
+    <nav aria-label="Page navigation">
     <ul class="pagination justify-content-center">
         {% if not skip == 0%}
         <li class="page-item"><a class="page-link" href="?type={{ type }}&limit={{limit}}&skip={{skip - limit}}">Previous</a></li>

--- a/app/templates/output_list.j2
+++ b/app/templates/output_list.j2
@@ -1,4 +1,16 @@
 <div class="row">
+    <h5>Filter by result type: </h5>
+    <div class="btn-group" id="filter_button" role="group" aria-label="Filter research type">
+    {% for type in ['publication', 'dataset', 'software', 'other'] %}
+        <a href="{{ url_for('output_list') }}?type={{ type }}&limit={{limit}}&skip=0" class="btn btn-primary">
+            {{type}}
+            <span class="badge text-bg-secondary">{{count[type]|default(0)}}</span>
+            </a>
+    {% endfor %}
+    </div>
+</div>
+
+<div class="row">
     {% if outputs %}
         {% for output in outputs %}
             <div class="card" id="{{output.uuid}}">
@@ -37,3 +49,25 @@
     {% endif %}
 </div>
 
+<div class="row">
+    <nav aria-label="Page navigation example">
+    <ul class="pagination justify-content-center">
+        {% if not skip == 0%}
+        <li class="page-item"><a class="page-link" href="?type={{ type }}&limit={{limit}}&skip={{skip - limit}}">Previous</a></li>
+        {% endif %}
+
+        {% for page in range((count[type] // limit) + 1) %}
+            {% set skipper = (page) * limit %}
+            {% if skipper == skip %}
+                <li class="page-item"><a class="page-link active" href="?type={{ type }}&limit={{limit}}&skip={{skipper}}">{{ page + 1 }}</a></li>
+            {% else %}
+                <li class="page-item"><a class="page-link" href="?type={{ type }}&limit={{limit}}&skip={{skipper}}">{{ page + 1 }}</a></li>
+            {% endif%}
+        {% endfor %}
+
+        {% if not skip >= count[type] - limit %}
+        <li class="page-item"><a class="page-link" href="?type={{ type }}&limit={{limit}}&skip={{skip + limit}}">Next</a></li>
+        {% endif %}
+    </ul>
+    </nav>
+</div>

--- a/app/templates/outputs.html
+++ b/app/templates/outputs.html
@@ -7,6 +7,43 @@
 
 <div class="container" id="research_products"></div>
 
+{{request.query_string|pprint}}
+
+<div class="row">
+    <h5>Filter by result type: </h5>
+    <div class="btn-group" id="filter_button" role="group" aria-label="Filter research type">
+    {% for type in ['publication', 'dataset', 'software', 'other'] %}
+        <a href="{{ url_for('output_list') }}?type={{ type }}&limit={{limit}}&skip=0" class="btn btn-primary">
+            {{type}}
+            <span class="badge text-bg-secondary">{{count[type]}}</span>
+            </a>
+    {% endfor %}
+    </div>
+</div>
+
 {% include 'output_list.j2' %}
+
+<div class="row">
+    <nav aria-label="Page navigation example">
+    <ul class="pagination">
+        {% if not skip == 0%}
+        <li class="page-item"><a class="page-link" href="?type={{ type }}&limit={{limit}}&skip={{skip - limit}}">Previous</a></li>
+        {% endif %}
+
+        {% for page in range((count[type] // limit) + 1) %}
+            {% set skipper = (page) * limit %}
+            {% if skipper == skip %}
+                <li class="page-item"><a class="page-link active" href="?type={{ type }}&limit={{limit}}&skip={{skipper}}">{{ page + 1 }}</a></li>
+            {% else %}
+                <li class="page-item"><a class="page-link" href="?type={{ type }}&limit={{limit}}&skip={{skipper}}">{{ page + 1 }}</a></li>
+            {% endif%}
+        {% endfor %}
+
+        {% if not skip >= count[type] - limit %}
+        <li class="page-item"><a class="page-link" href="?type={{ type }}&limit={{limit}}&skip={{skip + limit}}">Next</a></li>
+        {% endif %}
+    </ul>
+    </nav>
+</div>
 
 {% endblock %}

--- a/app/templates/outputs.html
+++ b/app/templates/outputs.html
@@ -7,8 +7,6 @@
 
 <div class="container" id="research_products"></div>
 
-{{request.query_string|pprint}}
-
 {% include 'output_list.j2' %}
 
 {% endblock %}

--- a/app/templates/outputs.html
+++ b/app/templates/outputs.html
@@ -5,8 +5,10 @@
 <script async src="https://badge.dimensions.ai/badge.js" charset="utf-8"></script>
 <script src='https://d1bxh8uas1mnw7.cloudfront.net/assets/embed.js'></script>
 
-<div class="container" id="research_products"></div>
+<div class="container" id="research_products">
 
 {% include 'output_list.j2' %}
+
+</div>
 
 {% endblock %}

--- a/app/templates/outputs.html
+++ b/app/templates/outputs.html
@@ -9,41 +9,6 @@
 
 {{request.query_string|pprint}}
 
-<div class="row">
-    <h5>Filter by result type: </h5>
-    <div class="btn-group" id="filter_button" role="group" aria-label="Filter research type">
-    {% for type in ['publication', 'dataset', 'software', 'other'] %}
-        <a href="{{ url_for('output_list') }}?type={{ type }}&limit={{limit}}&skip=0" class="btn btn-primary">
-            {{type}}
-            <span class="badge text-bg-secondary">{{count[type]}}</span>
-            </a>
-    {% endfor %}
-    </div>
-</div>
-
 {% include 'output_list.j2' %}
-
-<div class="row">
-    <nav aria-label="Page navigation example">
-    <ul class="pagination">
-        {% if not skip == 0%}
-        <li class="page-item"><a class="page-link" href="?type={{ type }}&limit={{limit}}&skip={{skip - limit}}">Previous</a></li>
-        {% endif %}
-
-        {% for page in range((count[type] // limit) + 1) %}
-            {% set skipper = (page) * limit %}
-            {% if skipper == skip %}
-                <li class="page-item"><a class="page-link active" href="?type={{ type }}&limit={{limit}}&skip={{skipper}}">{{ page + 1 }}</a></li>
-            {% else %}
-                <li class="page-item"><a class="page-link" href="?type={{ type }}&limit={{limit}}&skip={{skipper}}">{{ page + 1 }}</a></li>
-            {% endif%}
-        {% endfor %}
-
-        {% if not skip >= count[type] - limit %}
-        <li class="page-item"><a class="page-link" href="?type={{ type }}&limit={{limit}}&skip={{skip + limit}}">Next</a></li>
-        {% endif %}
-    </ul>
-    </nav>
-</div>
 
 {% endblock %}

--- a/main.py
+++ b/main.py
@@ -93,12 +93,14 @@ def author(request: Request,
 def author_list(request: Request, skip: int = 0, limit: int = 20):
     model = Author()
     entity = model.get_all(skip=skip, limit=limit)
+    count = model.count_authors()
     return templates.TemplateResponse(
         "authors.html", {"request": request,
                          "title": "Author List",
                          "authors": entity,
                          "skip": skip,
-                         "limit": limit}
+                         "limit": limit,
+                         "count": count}
     )
 
 

--- a/main.py
+++ b/main.py
@@ -93,13 +93,42 @@ def author_list(request: Request):
 
 
 @app.get("/outputs", response_class=HTMLResponse)
-def output_list(request: Request, type: str = None):
+def output_list(request: Request,
+                type: str = 'publication',
+                skip: int = 0,
+                limit: int = 20,
+                country: str = None):
+
     model = Output()
-    entity = model.filter_type(result_type=type) if type else model.get_all()
+    if country:
+        results = model.filter_country(result_type=type,
+                                       skip=skip,
+                                       limit=limit,
+                                       country=country)
+    else:
+        results = model.filter_type(result_type=type,
+                                    skip=skip,
+                                    limit=limit)
+
     count = model.count()
+
+    package = {
+        "meta": {"count": count,
+                 "db_response_time_ms": 0,
+                 "page": 0,
+                 "per_page": 0},
+        "results": results
+    }
+
     return templates.TemplateResponse(
         "outputs.html",
-        {"request": request, "title": "Output List", "outputs": entity, "count": count},
+        {"request": request,
+         "title": "Output List",
+         "outputs": package['results'],
+         "count": package['meta']['count'],
+         "type": type,
+         "skip": skip,
+         "limit": limit}
     )
 
 

--- a/main.py
+++ b/main.py
@@ -69,26 +69,36 @@ def country_list(request: Request):
 
 
 @app.get("/authors/{id}", response_class=HTMLResponse)
-def author(request: Request, id: str, type: str = None):
+def author(request: Request,
+           id: str,
+           type: str = 'publication',
+           skip: int = 0,
+           limit: int = 20):
     author_model = Author()
-    entity = author_model.get(id, result_type=type)
+    entity = author_model.get(id, result_type=type, skip=skip, limit=limit)
     count = author_model.count(id)
     return templates.TemplateResponse(
         "author.html",
-        {"request": request, "title": "Author",
+        {"request": request,
+         "title": "Author",
          "author": entity,
-         "count": count},
+         "count": count,
+         "skip": skip,
+         "limit": limit,
+         'type': type},
     )
 
 
 @app.get("/authors", response_class=HTMLResponse)
-def author_list(request: Request):
+def author_list(request: Request, skip: int = 0, limit: int = 20):
     model = Author()
-    entity = model.get_all()
+    entity = model.get_all(skip=skip, limit=limit)
     return templates.TemplateResponse(
         "authors.html", {"request": request,
                          "title": "Author List",
-                         "authors": entity}
+                         "authors": entity,
+                         "skip": skip,
+                         "limit": limit}
     )
 
 
@@ -245,11 +255,11 @@ def api_workstream(id: str) -> WorkstreamModel:
     return model.get(id)
 
 
-@app.get("api/topics")
+@app.get("/api/topics")
 def api_topics_list() -> List[TopicBaseModel]:
     raise NotImplementedError("Have not yet implemented topics in the database")
 
 
-@app.get("api/topics/{id}")
-def api_topics_list(id: str) -> TopicBaseModel:
+@app.get("/api/topics/{id}")
+def api_topic(id: str) -> TopicBaseModel:
     raise NotImplementedError("Have not yet implemented topics in the database")

--- a/main.py
+++ b/main.py
@@ -188,7 +188,7 @@ def api_author_list(skip: int = 0, limit: int = 20) -> AuthorListModel:
 
 
 @app.get("/api/countries/{id}")
-def api_country(id: str, type: str = None)-> OutputListModel:
+def api_country(id: str)-> CountryNodeModel:
     """Return a list of outputs filtered by the country id provided
 
     Arguments
@@ -204,9 +204,8 @@ def api_country(id: str, type: str = None)-> OutputListModel:
 
     """
     country_model = Country()
-    outputs, country = country_model.get(id, result_type=type)
-    count = country_model.count(id)
-    return {"outputs": outputs, "country": country, "count": count}
+    country = country_model.get(id)
+    return country
 
 
 @app.get("/api/countries")

--- a/main.py
+++ b/main.py
@@ -11,7 +11,7 @@ from app.crud.graph import Edges, Nodes
 from app.crud.output import Output
 from app.crud.workstream import Workstream
 
-from app.schemas.author import AuthorModel, AuthorListModel
+from app.schemas.author import AuthorListModel, AuthorOutputModel
 from app.schemas.country import CountryNodeModel
 from app.schemas.output import OutputModel, OutputListModel
 from app.schemas.workstream import WorkstreamBase, WorkstreamModel
@@ -154,7 +154,7 @@ def output(request: Request, id: str):
 
 
 @app.get("/api/authors/{id}")
-def api_author(id: str, type: str = None) -> AuthorModel:
+def api_author(id: str, type: str = None) -> AuthorOutputModel:
     author_model = Author()
     results = author_model.get(id, result_type=type)
     count = author_model.count(id)
@@ -167,9 +167,12 @@ def api_author(id: str, type: str = None) -> AuthorModel:
 
 
 @app.get("/api/authors")
-def api_author_list(skip: int = 0, limit: int = 20) -> List[AuthorListModel]:
+def api_author_list(skip: int = 0, limit: int = 20) -> AuthorListModel:
     model = Author()
-    return model.get_all(skip=skip, limit=limit)
+    authors = model.get_all(skip=skip, limit=limit)
+    count = model.count_authors()
+    return {'meta': {'count': {'total': count}},
+            'authors': authors}
 
 
 @app.get("/api/countries/{id}")

--- a/main.py
+++ b/main.py
@@ -42,9 +42,18 @@ def index(request: Request):
 
 
 @app.get("/countries/{id}", response_class=HTMLResponse)
-def country(request: Request, id: str, type: str = None):
+def country(request: Request,
+            id: str,
+            type: str = 'publication',
+            skip: int = 0,
+            limit: int = 20):
     country_model = Country()
-    outputs, country = country_model.get(id, result_type=type)
+    outputs_model = Output()
+    outputs = outputs_model.filter_country(result_type=type,
+                                           country=id,
+                                           skip=skip,
+                                           limit=limit)
+    country = country_model.get(id)
     count = country_model.count(id)
     return templates.TemplateResponse(
         "country.html",
@@ -54,6 +63,9 @@ def country(request: Request, id: str, type: str = None):
             "outputs": outputs,
             "country": country,
             "count": count,
+            "skip": skip,
+            "limit": limit,
+            "type": type
         },
     )
 


### PR DESCRIPTION
Closes #52.

I added pagination to the output and author lists in this pull request.

A list of outputs appears at `/outputs` and under `/authors/{id}` and `/country/{id}`
In addition, the list of authors `/authors` returns a long list of authors.

I've used the simplest approach: `skip` and `limit` parameters.  Given that the data turnover is relatively slow, we do not need to use a more advanced approach.

