### PR TITLE
51 refactor api code to enable re use of queries for api and html routes

### DIFF
--- a/app/api/author.py
+++ b/app/api/author.py
@@ -1,34 +1,32 @@
-from typing import List
 from fastapi import APIRouter, HTTPException
-from app.crud.author import Author 
-from app.schemas.author import AuthorModel, AuthorListModel
 
-router = APIRouter(
-    prefix="/api/authors",
-    tags=["authors"]
-)
+from app.crud.author import Author
+from app.schemas.author import AuthorListModel, AuthorOutputModel
 
-@router.get("", response_model=List[AuthorListModel])
-def list_authors(skip: int = 0, limit: int = 20):
+router = APIRouter(prefix="/api/authors", tags=["authors"])
+
+
+@router.get("")
+def api_author_list(skip: int = 0, limit: int = 20) -> AuthorListModel:
     model = Author()
-    return model.get_all(skip=skip, limit=limit)
+    authors = model.get_all(skip=skip, limit=limit)
+    count = model.count_authors()
+    return {"meta": {"count": {"total": count}}, "authors": authors}
 
-@router.get("/{id}", response_model=AuthorModel)
-def get_author(id: str, type: str = None):
+
+@router.get("/{id}")
+def get_author(id: str, type: str = None) -> AuthorOutputModel:
     author_model = Author()
     results = author_model.get(id, result_type=type)
-    
+
     if not results:
-        raise HTTPException(
-            status_code=404,
-            detail=f"Author with id {id} not found"
-        )
-        
+        raise HTTPException(status_code=404, detail=f"Author with id {id} not found")
+
     count = author_model.count(id)
-    results['outputs']['meta'] = {
+    results["outputs"]["meta"] = {
         "count": count,
         "db_response_time_ms": 0,
         "page": 0,
-        "per_page": 0
+        "per_page": 0,
     }
     return results

--- a/app/api/author.py
+++ b/app/api/author.py
@@ -13,6 +13,6 @@ def api_author_list(skip: int = 0, limit: int = 20) -> AuthorListModel:
 
 
 @router.get("/{id}")
-def api_author(id: str, type: str = 'publication', skip: int = 0, limit: int = 20) -> AuthorOutputModel:
+def api_author(id: str, result_type: str = 'publication', skip: int = 0, limit: int = 20) -> AuthorOutputModel:
     author = Author()
-    return author.get_author(id=id, type=type, skip=skip, limit=limit)
+    return author.get_author(id=id, result_type=result_type, skip=skip, limit=limit)

--- a/app/api/author.py
+++ b/app/api/author.py
@@ -1,0 +1,34 @@
+from typing import List
+from fastapi import APIRouter, HTTPException
+from app.crud.author import Author 
+from app.schemas.author import AuthorModel, AuthorListModel
+
+router = APIRouter(
+    prefix="/api/authors",
+    tags=["authors"]
+)
+
+@router.get("", response_model=List[AuthorListModel])
+def list_authors(skip: int = 0, limit: int = 20):
+    model = Author()
+    return model.get_all(skip=skip, limit=limit)
+
+@router.get("/{id}", response_model=AuthorModel)
+def get_author(id: str, type: str = None):
+    author_model = Author()
+    results = author_model.get(id, result_type=type)
+    
+    if not results:
+        raise HTTPException(
+            status_code=404,
+            detail=f"Author with id {id} not found"
+        )
+        
+    count = author_model.count(id)
+    results['outputs']['meta'] = {
+        "count": count,
+        "db_response_time_ms": 0,
+        "page": 0,
+        "per_page": 0
+    }
+    return results

--- a/app/api/author.py
+++ b/app/api/author.py
@@ -8,25 +8,11 @@ router = APIRouter(prefix="/api/authors", tags=["authors"])
 
 @router.get("")
 def api_author_list(skip: int = 0, limit: int = 20) -> AuthorListModel:
-    model = Author()
-    authors = model.get_all(skip=skip, limit=limit)
-    count = model.count_authors()
-    return {"meta": {"count": {"total": count}}, "authors": authors}
+    authors = Author()
+    return authors.get_authors(skip=skip, limit=limit)
 
 
 @router.get("/{id}")
-def get_author(id: str, type: str = None) -> AuthorOutputModel:
-    author_model = Author()
-    results = author_model.get(id, result_type=type)
-
-    if not results:
-        raise HTTPException(status_code=404, detail=f"Author with id {id} not found")
-
-    count = author_model.count(id)
-    results["outputs"]["meta"] = {
-        "count": count,
-        "db_response_time_ms": 0,
-        "page": 0,
-        "per_page": 0,
-    }
-    return results
+def api_author(id: str, type: str = 'publication', skip: int = 0, limit: int = 20) -> AuthorOutputModel:
+    author = Author()
+    return author.get_author(id=id, type=type, skip=skip, limit=limit)

--- a/app/api/country.py
+++ b/app/api/country.py
@@ -1,19 +1,19 @@
 from typing import List
+
 from fastapi import APIRouter, HTTPException
+
 from app.crud.country import Country
 from app.schemas.country import CountryNodeModel
 
-router = APIRouter(
-    prefix="/api/countries",
-    tags=["countries"]
-)
+router = APIRouter(prefix="/api/countries", tags=["countries"])
+
 
 @router.get("")
 def api_country_list() -> List[CountryNodeModel]:
     try:
         country_model = Country()
         if results := country_model.get_all():
-            return [result['c'] for result in results]
+            return [result["c"] for result in results]
         else:
             raise HTTPException(status_code=404, detail="No countries found")
     except Exception as e:

--- a/app/api/country.py
+++ b/app/api/country.py
@@ -12,9 +12,17 @@ router = APIRouter(prefix="/api/countries", tags=["countries"])
 def api_country_list() -> List[CountryNodeModel]:
     try:
         country_model = Country()
-        if results := country_model.get_all():
-            return [result["c"] for result in results]
+        return country_model.get_countries()
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=f"Server error: {str(e)}") from e
+
+@router.get("/{id}")
+def api_country(id: str,  skip: int = 0, limit: int = 20, type: str = "publication"):
+    try:
+        country_model = Country()
+        if result := country_model.get_country(id, skip, limit, type):
+            return result
         else:
-            raise HTTPException(status_code=404, detail="No countries found")
+            raise HTTPException(status_code=404, detail=f"Country with id {id} not found")
     except Exception as e:
         raise HTTPException(status_code=500, detail=f"Database error: {str(e)}") from e

--- a/app/api/country.py
+++ b/app/api/country.py
@@ -1,0 +1,28 @@
+from typing import List
+from fastapi import APIRouter, HTTPException
+from app.crud.country import Country
+from app.schemas.country import CountryNodeModel
+from app.schemas.output import OutputListModel
+
+router = APIRouter(
+    prefix="/api/countries",
+    tags=["countries"]
+)
+
+@router.get("", response_model=List[CountryNodeModel])
+def list_countries():
+    model = Country()
+    return model.get_all()
+
+# @router.get("/{id}", response_model=OutputListModel)
+# def get_country(id: str, type: str = None):
+#     model = Country()
+#     outputs, country = model.get(id, result_type=type)
+    
+#     if not country:
+#         raise HTTPException(
+#             status_code=404,
+#             detail=f"Country with id {id} not found"
+#         )
+        
+#     return {"items": outputs}

--- a/app/api/country.py
+++ b/app/api/country.py
@@ -2,27 +2,19 @@ from typing import List
 from fastapi import APIRouter, HTTPException
 from app.crud.country import Country
 from app.schemas.country import CountryNodeModel
-from app.schemas.output import OutputListModel
 
 router = APIRouter(
     prefix="/api/countries",
     tags=["countries"]
 )
 
-@router.get("", response_model=List[CountryNodeModel])
-def list_countries():
-    model = Country()
-    return model.get_all()
-
-# @router.get("/{id}", response_model=OutputListModel)
-# def get_country(id: str, type: str = None):
-#     model = Country()
-#     outputs, country = model.get(id, result_type=type)
-    
-#     if not country:
-#         raise HTTPException(
-#             status_code=404,
-#             detail=f"Country with id {id} not found"
-#         )
-        
-#     return {"items": outputs}
+@router.get("")
+def api_country_list() -> List[CountryNodeModel]:
+    try:
+        country_model = Country()
+        if results := country_model.get_all():
+            return [result['c'] for result in results]
+        else:
+            raise HTTPException(status_code=404, detail="No countries found")
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=f"Database error: {str(e)}") from e

--- a/app/api/country.py
+++ b/app/api/country.py
@@ -3,21 +3,28 @@ from typing import List
 from fastapi import APIRouter, HTTPException
 
 from app.crud.country import Country
-from app.schemas.country import CountryNodeModel
+from app.schemas.country import CountryList, CountryOutputListModel
 
 router = APIRouter(prefix="/api/countries", tags=["countries"])
 
 
 @router.get("")
-def api_country_list() -> List[CountryNodeModel]:
+def api_country_list(skip: int = 0,
+                     limit: int = 20
+                     ) -> CountryList:
     try:
         country_model = Country()
-        return country_model.get_countries()
+        return country_model.get_countries(skip, limit)
     except Exception as e:
-        raise HTTPException(status_code=500, detail=f"Server error: {str(e)}") from e
+        raise HTTPException(status_code=500,
+                            detail=f"Server error: {str(e)}") from e
 
 @router.get("/{id}")
-def api_country(id: str,  skip: int = 0, limit: int = 20, result_type: str = "publication"):
+def api_country(id: str,
+                skip: int = 0,
+                limit: int = 20,
+                result_type: str = "publication"
+                ) -> CountryOutputListModel:
     try:
         country_model = Country()
         if result := country_model.get_country(id, skip, limit, result_type):

--- a/app/api/country.py
+++ b/app/api/country.py
@@ -17,10 +17,10 @@ def api_country_list() -> List[CountryNodeModel]:
         raise HTTPException(status_code=500, detail=f"Server error: {str(e)}") from e
 
 @router.get("/{id}")
-def api_country(id: str,  skip: int = 0, limit: int = 20, type: str = "publication"):
+def api_country(id: str,  skip: int = 0, limit: int = 20, result_type: str = "publication"):
     try:
         country_model = Country()
-        if result := country_model.get_country(id, skip, limit, type):
+        if result := country_model.get_country(id, skip, limit, result_type):
             return result
         else:
             raise HTTPException(status_code=404, detail=f"Country with id {id} not found")

--- a/app/api/output.py
+++ b/app/api/output.py
@@ -1,0 +1,54 @@
+from fastapi import APIRouter, HTTPException
+from app.crud.output import Output
+from app.schemas.output import OutputModel, OutputListModel
+
+router = APIRouter(
+    prefix="/api/outputs",
+    tags=["outputs"]
+)
+
+@router.get("", response_model=OutputListModel)
+def api_output_list(skip: int = 0,
+                    limit: int = 20,
+                    type: str = 'publication',
+                    country: str = None) -> OutputListModel:
+    """Return a list of outputs"""
+    if skip < 0:
+        raise HTTPException(status_code=400, detail="Skip parameter must be non-negative")
+    if limit < 1:
+        raise HTTPException(status_code=400, detail="Limit parameter must be positive")
+
+    model = Output()
+    try:
+        if country:
+            results = model.filter_country(result_type=type,
+                                         skip=skip,
+                                         limit=limit,
+                                         country=country)
+        else:
+            results = model.filter_type(result_type=type,
+                                      skip=skip,
+                                      limit=limit)
+
+        count = model.count()
+
+        return {
+            "meta": {"count": count,
+                    "db_response_time_ms": 0,
+                    "page": 0,
+                    "per_page": 0},
+            "results": results
+        }
+    except ValueError as e:
+        raise HTTPException(status_code=400, detail=str(e)) from e
+
+@router.get("/{id}", response_model=OutputModel)
+def api_output(id: str) -> OutputModel:
+    output_model = Output()
+    try:
+        result = output_model.get(id)
+        if result is None:
+            raise HTTPException(status_code=404, detail=f"Output with id {id} not found")
+        return result
+    except ValueError as e:
+        raise HTTPException(status_code=400, detail=str(e)) from e

--- a/app/api/output.py
+++ b/app/api/output.py
@@ -8,7 +8,7 @@ router = APIRouter(prefix="/api/outputs", tags=["outputs"])
 
 @router.get("")
 def api_output_list(
-    skip: int = 0, limit: int = 20, type: str = "publication", country: str = None
+    skip: int = 0, limit: int = 20, result_type: str = "publication", country: str = None
 ) -> OutputListModel:
     """Return a list of outputs"""
     if skip < 0:
@@ -20,7 +20,7 @@ def api_output_list(
 
     outputs = Output()
     try:
-        return outputs.get_outputs(skip, limit, type, country)
+        return outputs.get_outputs(skip, limit, result_type, country)
     except ValueError as e:
         raise HTTPException(status_code=400, detail=str(e)) from e
 

--- a/app/api/output.py
+++ b/app/api/output.py
@@ -18,35 +18,18 @@ def api_output_list(
     if limit < 1:
         raise HTTPException(status_code=400, detail="Limit parameter must be positive")
 
-    model = Output()
+    outputs = Output()
     try:
-        if country:
-            results = model.filter_country(
-                result_type=type, skip=skip, limit=limit, country=country
-            )
-        else:
-            results = model.filter_type(result_type=type, skip=skip, limit=limit)
-
-        count = model.count()
-
-        return {
-            "meta": {
-                "count": count,
-                "db_response_time_ms": 0,
-                "page": 0,
-                "per_page": 0,
-            },
-            "results": results,
-        }
+        return outputs.get_outputs(skip, limit, type, country)
     except ValueError as e:
         raise HTTPException(status_code=400, detail=str(e)) from e
 
 
 @router.get("/{id}")
 def api_output(id: str) -> OutputModel:
-    output_model = Output()
+    output = Output()
     try:
-        result = output_model.get(id)
+        result = output.get_output(id)
         if result is None:
             raise HTTPException(
                 status_code=404, detail=f"Output with id {id} not found"

--- a/app/api/output.py
+++ b/app/api/output.py
@@ -1,54 +1,56 @@
 from fastapi import APIRouter, HTTPException
+
 from app.crud.output import Output
-from app.schemas.output import OutputModel, OutputListModel
+from app.schemas.output import OutputListModel, OutputModel
 
-router = APIRouter(
-    prefix="/api/outputs",
-    tags=["outputs"]
-)
+router = APIRouter(prefix="/api/outputs", tags=["outputs"])
 
-@router.get("", response_model=OutputListModel)
-def api_output_list(skip: int = 0,
-                    limit: int = 20,
-                    type: str = 'publication',
-                    country: str = None) -> OutputListModel:
+
+@router.get("")
+def api_output_list(
+    skip: int = 0, limit: int = 20, type: str = "publication", country: str = None
+) -> OutputListModel:
     """Return a list of outputs"""
     if skip < 0:
-        raise HTTPException(status_code=400, detail="Skip parameter must be non-negative")
+        raise HTTPException(
+            status_code=400, detail="Skip parameter must be non-negative"
+        )
     if limit < 1:
         raise HTTPException(status_code=400, detail="Limit parameter must be positive")
 
     model = Output()
     try:
         if country:
-            results = model.filter_country(result_type=type,
-                                         skip=skip,
-                                         limit=limit,
-                                         country=country)
+            results = model.filter_country(
+                result_type=type, skip=skip, limit=limit, country=country
+            )
         else:
-            results = model.filter_type(result_type=type,
-                                      skip=skip,
-                                      limit=limit)
+            results = model.filter_type(result_type=type, skip=skip, limit=limit)
 
         count = model.count()
 
         return {
-            "meta": {"count": count,
-                    "db_response_time_ms": 0,
-                    "page": 0,
-                    "per_page": 0},
-            "results": results
+            "meta": {
+                "count": count,
+                "db_response_time_ms": 0,
+                "page": 0,
+                "per_page": 0,
+            },
+            "results": results,
         }
     except ValueError as e:
         raise HTTPException(status_code=400, detail=str(e)) from e
 
-@router.get("/{id}", response_model=OutputModel)
+
+@router.get("/{id}")
 def api_output(id: str) -> OutputModel:
     output_model = Output()
     try:
         result = output_model.get(id)
         if result is None:
-            raise HTTPException(status_code=404, detail=f"Output with id {id} not found")
+            raise HTTPException(
+                status_code=404, detail=f"Output with id {id} not found"
+            )
         return result
     except ValueError as e:
         raise HTTPException(status_code=400, detail=str(e)) from e

--- a/app/api/topics.py
+++ b/app/api/topics.py
@@ -1,12 +1,11 @@
 from typing import List
+
 from fastapi import APIRouter
+
 from app.schemas.topic import TopicBaseModel
 
+router = APIRouter(prefix="/api/topics", tags=["countries"])
 
-router = APIRouter(
-    prefix="/api/topics",
-    tags=["countries"]
-)
 
 @router.get("")
 def api_topics_list() -> List[TopicBaseModel]:

--- a/app/api/topics.py
+++ b/app/api/topics.py
@@ -1,0 +1,18 @@
+from typing import List
+from fastapi import APIRouter
+from app.schemas.topic import TopicBaseModel
+
+
+router = APIRouter(
+    prefix="/api/topics",
+    tags=["countries"]
+)
+
+@router.get("")
+def api_topics_list() -> List[TopicBaseModel]:
+    raise NotImplementedError("Have not yet implemented topics in the database")
+
+
+@router.get("/{id}")
+def api_topics_list(id: str) -> TopicBaseModel:
+    raise NotImplementedError("Have not yet implemented topics in the database")

--- a/app/api/workstream.py
+++ b/app/api/workstream.py
@@ -16,10 +16,4 @@ def list_workstreams() -> List[WorkstreamBase]:
 
 @router.get("/{id}")
 def get_workstream(id: str) -> WorkstreamModel:
-    model = Workstream()
-    result = model.get(id)
-    if result is None:
-        raise HTTPException(
-            status_code=404, detail=f"Workstream with id {id} not found"
-        )
-    return result
+    raise NotImplementedError("Implementation of workstream and author relationships is not yet complete")

--- a/app/api/workstream.py
+++ b/app/api/workstream.py
@@ -1,25 +1,25 @@
 from typing import List
+
 from fastapi import APIRouter, HTTPException
-from app.crud.workstream import Workstream 
+
+from app.crud.workstream import Workstream
 from app.schemas.workstream import WorkstreamBase, WorkstreamModel
 
-router = APIRouter(
-    prefix="/api/workstreams",
-    tags=["workstreams"]
-)
+router = APIRouter(prefix="/api/workstreams", tags=["workstreams"])
 
-@router.get("", response_model=List[WorkstreamBase])
-def list_workstreams():
+
+@router.get("")
+def list_workstreams() -> List[WorkstreamBase]:
     model = Workstream()
     return model.get_all()
 
-@router.get("/{id}", response_model=WorkstreamModel)
-def get_workstream(id: str):
+
+@router.get("/{id}")
+def get_workstream(id: str) -> WorkstreamModel:
     model = Workstream()
     result = model.get(id)
     if result is None:
         raise HTTPException(
-            status_code=404,
-            detail=f"Workstream with id {id} not found"
+            status_code=404, detail=f"Workstream with id {id} not found"
         )
     return result

--- a/app/api/workstream.py
+++ b/app/api/workstream.py
@@ -1,0 +1,25 @@
+from typing import List
+from fastapi import APIRouter, HTTPException
+from app.crud.workstream import Workstream 
+from app.schemas.workstream import WorkstreamBase, WorkstreamModel
+
+router = APIRouter(
+    prefix="/api/workstreams",
+    tags=["workstreams"]
+)
+
+@router.get("", response_model=List[WorkstreamBase])
+def list_workstreams():
+    model = Workstream()
+    return model.get_all()
+
+@router.get("/{id}", response_model=WorkstreamModel)
+def get_workstream(id: str):
+    model = Workstream()
+    result = model.get(id)
+    if result is None:
+        raise HTTPException(
+            status_code=404,
+            detail=f"Workstream with id {id} not found"
+        )
+    return result

--- a/app/crud/author.py
+++ b/app/crud/author.py
@@ -168,7 +168,8 @@ class Author:
         publications = self.fetch_publications(id, result_type=type, skip=skip, limit=limit)
         author['collaborators'] = collaborators
         author['outputs'] = {'results': publications}
-        author['outputs']['meta'] = {"count": count,
+        author['outputs']['meta'] = {"count":
+                                            {"total": count},
                                     "db_response_time_ms": 0,
                                     "page": 0,
                                     "per_page": 0}

--- a/app/crud/author.py
+++ b/app/crud/author.py
@@ -1,4 +1,3 @@
-from datetime import datetime
 from typing import Any, Dict, List, Optional
 
 from neo4j import Driver

--- a/app/crud/author.py
+++ b/app/crud/author.py
@@ -3,6 +3,8 @@ from typing import Any, Dict, List, Optional, Tuple
 from neo4j import Driver
 
 from app.db.session import connect_to_db
+from app.schemas.author import AuthorListModel, AuthorOutputModel
+
 
 class Author:
     @connect_to_db
@@ -30,7 +32,7 @@ class Author:
 
         return [record.data() for record in records][0]["count"]
 
-    def get_authors(self, skip: int, limit: int) -> List[Dict[str, Any]]:
+    def get_authors(self, skip: int, limit: int) -> AuthorListModel:
         records, summary, keys = self.fetch_author_nodes(skip=skip, limit=limit)
         authors = [record.data() for record in records]
         count = self.count_authors()
@@ -160,7 +162,7 @@ class Author:
 
         return publications
 
-    def get_author(self, id: str, type: str = 'publication', skip: int = 0, limit: int = 20):
+    def get_author(self, id: str, type: str = 'publication', skip: int = 0, limit: int = 20) -> AuthorOutputModel:
         author = self.fetch_author_node(id)
         collaborators = self.fetch_collaborator_nodes(id, type)[0]
         collaborators = [collaborator.data() for collaborator in collaborators]

--- a/app/crud/author.py
+++ b/app/crud/author.py
@@ -168,8 +168,7 @@ class Author:
         publications = self.fetch_publications(id, result_type=type, skip=skip, limit=limit)
         author['collaborators'] = collaborators
         author['outputs'] = {'results': publications}
-        author['outputs']['meta'] = {"count":
-                                            {"total": count},
+        author['outputs']['meta'] = {"count":count,
                                     "db_response_time_ms": 0,
                                     "page": 0,
                                     "per_page": 0}

--- a/app/crud/author.py
+++ b/app/crud/author.py
@@ -1,59 +1,43 @@
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Optional, Tuple
 
 from neo4j import Driver
 
 from app.db.session import connect_to_db
 
-
 class Author:
     @connect_to_db
-    def get(
-        self, id: str, db: Driver,
-        result_type: Optional[str] = None,
-        limit: int = 20,
-        skip: int = 0
-    ) -> Dict[str, Any]:
-        """Retrieve author information from the database.
+    def fetch_author_nodes(
+        self, db: Driver, skip: int, limit: int
+    ) -> List[Dict[str, Any]]:
+        query = """
+            MATCH (a:Author)
+            OPTIONAL MATCH (a)-[:member_of]->(p:Partner)
+            OPTIONAL MATCH (a)-[:member_of]->(u:Workstream)
+            RETURN a.first_name as first_name, a.last_name as last_name, a.uuid as uuid, a.orcid as orcid,
+                collect(DISTINCT p) as affiliations, collect(DISTINCT u) as workstreams
+            ORDER BY last_name
+            SKIP $skip
+            LIMIT $limit;"""
+        return db.execute_query(query, skip=skip, limit=limit)
 
-        Parameters
-        ----------
-        id : str
-            UUID of the author
-        db : Driver
-            Neo4j database driver
-        result_type : str, optional
-            Type of result formatting
+    @connect_to_db
+    def count_authors(self, db: Driver) -> int:
+        """Count the number of authors"""
+        query = """MATCH (a:Author)
+                RETURN COUNT(a) as count
+                """
+        records, summary, keys = db.execute_query(query)
 
-        Returns
-        -------
-        dict
-            Author information dictionary containing:
-            - uuid : str
-                Author's unique identifier
-            - orcid : str
-                Author's ORCID
-            - first_name : str
-                Author's first name
-            - last_name : str
-                Author's last name
-            - affiliations : list
-                List of partner affiliations
-            - workstreams : list
-                List of associated workstreams
-        Notes
-        -----
-        Example Neo4j queries:
+        return [record.data() for record in records][0]["count"]
 
-        MATCH (a:Author)
-        RETURN a.first_name as first_name, a.last_name as last_name,
-            p.name as affiliation;
+    def get_authors(self, skip: int, limit: int) -> List[Dict[str, Any]]:
+        records, summary, keys = self.fetch_author_nodes(skip=skip, limit=limit)
+        authors = [record.data() for record in records]
+        count = self.count_authors()
+        return {"meta": {"count": {"total": count}}, "authors": authors}
 
-        MATCH (a:Author)-[r:author_of]->(p:Article)
-        OPTIONAL MATCH (a:Author)-[:member_of]->(p:Partner)
-        WHERE a.uuid = $uuid
-        RETURN *;
-        """
-        outputs = []
+    @connect_to_db
+    def fetch_author_node(self, id: str, db: Driver) -> Dict[str, Any]:
         author_query = """
             MATCH (a:Author)
             WHERE a.uuid = $uuid
@@ -63,10 +47,33 @@ class Author:
                     a.first_name as first_name, a.last_name as last_name,
                     collect(DISTINCT p) as affiliations,
                     collect(DISTINCT u) as workstreams;"""
+        records, summary, keys = db.execute_query(author_query, uuid=id)
+        return records[0].data()
 
-        author, _, _ = db.execute_query(author_query, uuid=id)
-        results = author[0].data()
+    @connect_to_db
+    def count_author_outputs(self, id: str, db: Driver) -> int:
+        query = """
+                MATCH (a:Author)-[b:author_of]->(o:Article)
+                WHERE (a.uuid) = $uuid
+                RETURN o.result_type as result_type, count(DISTINCT o) as count
+                """
+        records, summary, keys = db.execute_query(query, uuid=id)
+        if len(records) <= 0:
+            return {
+                "total": 0,
+                "publications": 0,
+                "datasets": 0,
+                "other": 0,
+                "software": 0,
+            }
+        counts = {x.data()["result_type"]: x.data()["count"] for x in records}
+        counts["total"] = sum(counts.values())
+        return counts
 
+    @connect_to_db
+    def fetch_collaborator_nodes(
+        self, id: str, result_type: str, db: Driver
+    ) -> List[Dict[str, Any]]:
         collab_query = """
             MATCH (a:Author)-[:author_of]->(z:Output)<-[:author_of]-(b:Author)
             WHERE a.uuid = $uuid AND b.uuid <> $uuid AND z.result_type = $type
@@ -77,13 +84,18 @@ class Author:
                    count(z) as num_colabs
             ORDER BY num_colabs DESCENDING
             LIMIT 5"""
-        collab, _, _ = db.execute_query(collab_query,
-                                        uuid=id,
-                                        type=result_type)
+        return db.execute_query(collab_query, uuid=id, type=result_type)
 
-        results["collaborators"] = [x.data() for x in collab]
-
-        if result_type and result_type in [
+    @connect_to_db
+    def fetch_publications(
+        self,
+        id: str,
+        db: Driver,
+        result_type: Optional[str] = None,
+        limit: int = 20,
+        skip: int = 0,
+    ) -> Tuple:
+        if result_type in [
             "publication",
             "dataset",
             "software",
@@ -107,12 +119,12 @@ class Author:
                 LIMIT $limit
                 ;"""
 
-            records, _, _ = db.execute_query(
+            records, summary, keys = db.execute_query(
                 publications_query,
                 uuid=id,
                 result_type=result_type,
                 skip=skip,
-                limit=limit
+                limit=limit,
             )
 
         else:
@@ -134,77 +146,30 @@ class Author:
                 LIMIT $limit
                 ;"""
 
-            records, _, _ = db.execute_query(publications_query,
-                                             uuid=id,
-                                             limit=limit,
-                                             skip=skip)
-        for x in records:
-            data = x.data()
-            package = data['results']
-            package['authors'] = data['authors']
-            package['countries'] = data['countries']
-            outputs.append(package)
+            records, summary, keys = db.execute_query(
+                publications_query, uuid=id, limit=limit, skip=skip
+            )
+        publications = []
 
-        results['outputs'] = {}
-        results['outputs']['results'] = outputs
-        return results
+        for record in records:
+            data = record.data()
+            package = data["results"]
+            package["authors"] = data["authors"]
+            package["countries"] = data["countries"]
+            publications.append(package)
 
-    @connect_to_db
-    def count(self, id: str, db: Driver) -> Dict[str, int]:
-        """Returns counts of articles by result type for a given author.
+        return publications
 
-        Parameters
-        ----------
-        id : str
-            UUID of the author
-        db : Driver
-            Neo4j database driver
-
-        Returns
-        -------
-        Dict[str, int]
-            Dictionary mapping result types to their counts
-        """
-        query = """
-                MATCH (a:Author)-[b:author_of]->(o:Article)
-                WHERE (a.uuid) = $uuid
-                RETURN o.result_type as result_type, count(DISTINCT o) as count
-                """
-        records, summary, keys = db.execute_query(query, uuid=id)
-        if len(records) > 0:
-            counts = {x.data()["result_type"]: x.data()["count"] for x in records}
-            counts['total'] = sum(counts.values())
-            return counts
-        else:
-            return {'total': 0,
-                    'publications': 0,
-                    'datasets': 0,
-                    'other': 0,
-                    'software': 0}
-
-    @connect_to_db
-    def get_all(self, db: Driver, skip: int, limit: int) -> List[Dict[str, Any]]:
-        """Retrieve list of authors from the database."""
-        query = """MATCH (a:Author)
-                   OPTIONAL MATCH (a)-[:member_of]->(p:Partner)
-                   OPTIONAL MATCH (a)-[:member_of]->(u:Workstream)
-                   RETURN a.first_name as first_name, a.last_name as last_name, a.uuid as uuid, a.orcid as orcid, collect(DISTINCT p) as affiliations, collect(DISTINCT u) as workstreams
-                   ORDER BY last_name
-                   SKIP $skip
-                   LIMIT $limit;
-                   """
-        records, summary, keys = db.execute_query(query,
-                                                  skip=skip,
-                                                  limit=limit)
-
-        return [record.data() for record in records]
-
-    @connect_to_db
-    def count_authors(self, db: Driver) -> int:
-        """Count the number of authors"""
-        query = """MATCH (a:Author)
-                RETURN COUNT(a) as count
-                """
-        records, _, _ = db.execute_query(query)
-
-        return [record.data() for record in records][0]['count']
+    def get_author(self, id: str, type: str = 'publication', skip: int = 0, limit: int = 20):
+        author = self.fetch_author_node(id)
+        collaborators = self.fetch_collaborator_nodes(id, type)[0]
+        collaborators = [collaborator.data() for collaborator in collaborators]
+        count = self.count_author_outputs(id)
+        publications = self.fetch_publications(id, result_type=type, skip=skip, limit=limit)
+        author['collaborators'] = collaborators
+        author['outputs'] = {'results': publications}
+        author['outputs']['meta'] = {"count": count,
+                                    "db_response_time_ms": 0,
+                                    "page": 0,
+                                    "per_page": 0}
+        return author

--- a/app/crud/author.py
+++ b/app/crud/author.py
@@ -28,12 +28,12 @@ class Author:
         query = """MATCH (a:Author)
                 RETURN COUNT(a) as count
                 """
-        records, summary, keys = db.execute_query(query)
+        records, _, _ = db.execute_query(query)
 
         return [record.data() for record in records][0]["count"]
 
     def get_authors(self, skip: int, limit: int) -> AuthorListModel:
-        records, summary, keys = self.fetch_author_nodes(skip=skip, limit=limit)
+        records, _, _ = self.fetch_author_nodes(skip=skip, limit=limit)
         authors = [record.data() for record in records]
         count = self.count_authors()
         return {"meta": {"count": {"total": count}}, "authors": authors}
@@ -49,13 +49,13 @@ class Author:
                     a.first_name as first_name, a.last_name as last_name,
                     collect(DISTINCT p) as affiliations,
                     collect(DISTINCT u) as workstreams;"""
-        records, summary, keys = db.execute_query(author_query, uuid=id)
+        records, _, _ = db.execute_query(author_query, uuid=id)
         return records[0].data()
 
     @connect_to_db
     def count_author_outputs(self, id: str, db: Driver) -> int:
         query = """
-                MATCH (a:Author)-[b:author_of]->(o:Article)
+                MATCH (a:Author)-[b:author_of]->(o:Output)
                 WHERE (a.uuid) = $uuid
                 RETURN o.result_type as result_type, count(DISTINCT o) as count
                 """
@@ -112,7 +112,7 @@ class Author:
                     RETURN b
                     ORDER BY r.rank
                 }
-                OPTIONAL MATCH (p)-[:REFERS_TO]->(c:Country)
+                OPTIONAL MATCH (p)-[:refers_to]->(c:Country)
                 RETURN p as results,
                        collect(DISTINCT c) as countries,
                        collect(DISTINCT b) as authors
@@ -139,7 +139,7 @@ class Author:
                     RETURN b
                     ORDER BY r.rank
                 }
-                OPTIONAL MATCH (p)-[:REFERS_TO]->(c:Country)
+                OPTIONAL MATCH (p)-[:refers_to]->(c:Country)
                 RETURN p as results,
                     collect(DISTINCT c) as countries,
                     collect(DISTINCT b) as authors

--- a/app/crud/country.py
+++ b/app/crud/country.py
@@ -8,7 +8,6 @@ from .output import Output
 from app.schemas.country import CountryNodeModel
 
 
-
 class Country:
     @connect_to_db
     def fetch_country_node(self, id: str, db: Driver) -> Dict[str, Any]:
@@ -50,11 +49,11 @@ class Country:
             - values: count of articles for each result type
         """
         query = """
-                MATCH (o:Article)-[:REFERS_TO]->(c:Country)
+                MATCH (o:Output)-[:refers_to]->(c:Country)
                 WHERE c.id = $id
                 RETURN o.result_type as result_type, count(o) as count
                 """
-        records, summary, keys = db.execute_query(query, id=id)
+        records, _, _ = db.execute_query(query, id=id)
         return {x.data()["result_type"]: x.data()["count"] for x in records}
 
     @connect_to_db
@@ -72,11 +71,11 @@ class Country:
             List of dictionaries, each containing country properties
             from the Neo4j database
         """
-        query = """MATCH (c:Country)<-[:REFERS_TO]-(p:Article)
-                RETURN DISTINCT c
+        query = """MATCH (c:Country)<-[:refers_to]-(p:Output)
+                RETURN DISTINCT c as country
                 """
-        results, summary, keys = db.execute_query(query)
-        return [result.data()["c"] for result in results]
+        results, _, _ = db.execute_query(query)
+        return [result.data()['country'] for result in results]
 
     def get_country(self, id, skip, limit, type) -> Dict[str, Any]:
         entity = self.fetch_country_node(id)

--- a/app/crud/country.py
+++ b/app/crud/country.py
@@ -5,6 +5,9 @@ from neo4j import Driver
 from app.db.session import connect_to_db
 from .output import Output
 
+from app.schemas.country import CountryNodeModel
+
+
 
 class Country:
     @connect_to_db
@@ -55,7 +58,7 @@ class Country:
         return {x.data()["result_type"]: x.data()["count"] for x in records}
 
     @connect_to_db
-    def get_countries(self, db: Driver) -> List[Dict[str, Any]]:
+    def get_countries(self, db: Driver) -> List[CountryNodeModel]:
         """Retrieve all countries that have associated articles.
 
         Parameters

--- a/app/crud/country.py
+++ b/app/crud/country.py
@@ -5,10 +5,61 @@ from neo4j import Driver
 from app.db.session import connect_to_db
 from .output import Output
 
-from app.schemas.country import CountryNodeModel
+from app.schemas.country import (CountryList,
+                                 CountryNodeModel,
+                                 CountryOutputListModel)
+from app.schemas.meta import CountPublication
 
 
 class Country:
+
+    def get_country(self,
+                    id: str,
+                    skip: int = 0,
+                    limit: int = 20,
+                    result_type: str = 'publication'
+                    ) -> CountryOutputListModel:
+        """Return a country
+
+        Arguments
+        ---------
+        id: str
+            Three letter country code
+        skip: int = 0
+        limit: int = 20
+        result_type: str = 'publication'
+
+        Returns
+        -------
+        schemas.output.CountryOutputListModel
+        """
+        entity = self.fetch_country_node(id)
+        outputs = Output()
+        package = outputs.get_outputs(skip=skip,
+                                      limit=limit,
+                                      result_type=result_type,
+                                      country=id)
+        counts = self.count_country_outputs(id)
+        package["meta"]["count"] = counts
+        return package | entity
+
+    def get_countries(self, skip: int = 0, limit: int = 20) -> CountryList:
+        """Get a list of countries
+
+        Arguments
+        ---------
+        skip: int, default=0
+        limit: int, default=20
+
+        Returns
+        -------
+        schemas.country.CountryList
+        """
+        results = self.get_country_list(skip=skip, limit=limit)
+        count = self.count_countries()
+        return {"meta": {"count": {'total': count}, "skip": skip, "limit": limit},
+                "results": results}
+
     @connect_to_db
     def fetch_country_node(self, id: str, db: Driver) -> Dict[str, Any]:
         """Retrieve country information
@@ -31,7 +82,7 @@ class Country:
         return results[0].data()["country"]
 
     @connect_to_db
-    def count_country_outputs(self, id: str, db: Driver) -> Dict[str, int]:
+    def count_country_outputs(self, id: str, db: Driver) -> CountPublication:
         """Count articles by result type for a specific country.
 
         Parameters
@@ -51,13 +102,33 @@ class Country:
         query = """
                 MATCH (o:Output)-[:refers_to]->(c:Country)
                 WHERE c.id = $id
-                RETURN o.result_type as result_type, count(o) as count
+                RETURN o.result_type as result_type, count(DISTINCT o) as count
                 """
         records, _, _ = db.execute_query(query, id=id)
-        return {x.data()["result_type"]: x.data()["count"] for x in records}
+        if len(records) <= 0:
+            return {'total': 0,
+                    'publication': 0,
+                    'dataset': 0,
+                    'other': 0,
+                    'software': 0}
+        counts = {x.data()["result_type"]: x.data()["count"] for x in records}
+        counts['total'] = sum(counts.values())
+
+        return CountPublication(**counts)
 
     @connect_to_db
-    def get_countries(self, db: Driver) -> List[CountryNodeModel]:
+    def count_countries(self, db: Driver) -> int:
+        """Count the countries"""
+        query = """MATCH (c:Country)<-[:refers_to]-(p:Output)
+                   RETURN count(DISTINCT c.id) as count"""
+        results, _, _ = db.execute_query(query)
+        return results[0].data()['count']
+
+    @connect_to_db
+    def get_country_list(self,
+                         db: Driver,
+                         skip: int = 0,
+                         limit: int = 20) -> list[CountryNodeModel]:
         """Retrieve all countries that have associated articles.
 
         Parameters
@@ -67,19 +138,12 @@ class Country:
 
         Returns
         -------
-        List[Dict[str, Any]]
-            List of dictionaries, each containing country properties
-            from the Neo4j database
+        list[schemas.country.CountryNodeModel]
         """
         query = """MATCH (c:Country)<-[:refers_to]-(p:Output)
                 RETURN DISTINCT c as country
+                SKIP $skip
+                LIMIT $limit
                 """
-        results, _, _ = db.execute_query(query)
-        return [result.data()['country'] for result in results]
-
-    def get_country(self, id, skip, limit, type) -> Dict[str, Any]:
-        entity = self.fetch_country_node(id)
-        outputs = Output()
-        package = outputs.get_outputs(skip=skip, limit=limit, type=type, country=id)
-        package["country"] = entity
-        return package
+        records, _, _ = db.execute_query(query, skip=skip, limit=limit)
+        return [result.data()['country'] for result in records]

--- a/app/crud/country.py
+++ b/app/crud/country.py
@@ -1,7 +1,6 @@
-from typing import Any, Dict, List, Optional, Tuple
+from typing import Any, Dict, List
 
 from neo4j import Driver
-from datetime import datetime
 
 from app.db.session import connect_to_db
 

--- a/app/crud/graph.py
+++ b/app/crud/graph.py
@@ -38,7 +38,7 @@ class Nodes:
         query = """MATCH (a:Author)
                 RETURN a.uuid as id, 0 as group, a.first_name + " " + a.last_name as name, a.orcid as url
                 UNION ALL
-                MATCH (b:Article)
+                MATCH (b:Output)
                 RETURN b.uuid as id, 1 as group, b.title as name, "https://doi.org/" + b.doi as url
                 """
         results, summary, keys = db.execute_query(query)
@@ -71,7 +71,7 @@ class Edges:
         Neo4jError
             If database query fails
         """
-        query = """MATCH (p:Article)<-[author_of]-(a:Author)
+        query = """MATCH (p:Output)<-[author_of]-(a:Author)
                 RETURN p.uuid as target, a.uuid as source
                 """
         results, summary, keys = db.execute_query(query)

--- a/app/crud/output.py
+++ b/app/crud/output.py
@@ -38,9 +38,9 @@ class Output:
         """
 
         query = """
-                MATCH (o:Article)
+                MATCH (o:Output)
                 WHERE o.uuid = $uuid
-                OPTIONAL MATCH (o)-[:REFERS_TO]->(c:Country)
+                OPTIONAL MATCH (o)-[:refers_to]->(c:Country)
                 CALL
                 {
                 WITH o
@@ -50,7 +50,7 @@ class Output:
                 }
                 RETURN o as outputs, collect(DISTINCT c) as countries, collect(DISTINCT a) as authors
                 """
-        records, summary, keys = db.execute_query(query,
+        records, _, _ = db.execute_query(query,
                                                         uuid=id)
         data = [x.data() for x in records][0]
         package = data['outputs']
@@ -75,10 +75,10 @@ class Output:
             Example: {'journal_article': 5, 'conference_paper': 3}
         """
         query = """
-                MATCH (a:Author)-[b:author_of]->(o:Article)
+                MATCH (a:Author)-[b:author_of]->(o:Output)
                 RETURN o.result_type as result_type, count(DISTINCT o) as count
                 """
-        records, summary, keys = db.execute_query(query)
+        records, _, _ = db.execute_query(query)
         if len(records) <= 0:
             return {'total': 0,
                     'publications': 0,
@@ -119,7 +119,7 @@ class Output:
         query = """
                 MATCH (o:Output)
                 WHERE o.result_type = $result_type
-                OPTIONAL MATCH (o)-[:REFERS_TO]->(c:Country)
+                OPTIONAL MATCH (o)-[:refers_to]->(c:Country)
                 CALL
                 {
                 WITH o
@@ -134,7 +134,7 @@ class Output:
                 SKIP $skip
                 LIMIT $limit;
         """
-        records, summary, keys = db.execute_query(query,
+        records, _, _ = db.execute_query(query,
                                          result_type=result_type,
                                          skip=skip,
                                          limit=limit)
@@ -187,7 +187,7 @@ class Output:
             If result_type is invalid
         """
         query = """
-                MATCH (o:Article)-[:REFERS_TO]->(c:Country)
+                MATCH (o:Output)-[:refers_to]->(c:Country)
                 WHERE o.result_type = $result_type
                 AND c.id = $country_id
                 CALL

--- a/app/crud/output.py
+++ b/app/crud/output.py
@@ -3,11 +3,12 @@ from typing import Any, Dict, List
 from neo4j import Driver
 
 from app.db.session import connect_to_db
+from app.schemas.output import OutputListModel, OutputModel
 
 
 class Output:
     @connect_to_db
-    def get_output(self, id: str, db: Driver) -> Dict[str, Any]:
+    def get_output(self, id: str, db: Driver) -> OutputModel:
         """Retrieve article output information from the database.
 
         Parameters
@@ -217,7 +218,7 @@ class Output:
 
         return outputs
 
-    def get_outputs(self, skip, limit, type, country):
+    def get_outputs(self, skip:int , limit:int, type: str, country:str) -> OutputListModel:
         """Return a list of outputs"""
         try:
             if country:

--- a/app/crud/output.py
+++ b/app/crud/output.py
@@ -218,24 +218,30 @@ class Output:
 
         return outputs
 
-    def get_outputs(self, skip:int , limit:int, type: str, country:str) -> OutputListModel:
+    def get_outputs(self,
+                    skip: int,
+                    limit: int,
+                    result_type: str,
+                    country: str) -> OutputListModel:
         """Return a list of outputs"""
         try:
             if country:
                 results = self.filter_country(
-                    result_type=type, skip=skip, limit=limit, country=country
+                    result_type=result_type, skip=skip, limit=limit, country=country
                 )
             else:
-                results = self.filter_type(result_type=type, skip=skip, limit=limit)
+                results = self.filter_type(result_type=result_type,
+                                           skip=skip,
+                                           limit=limit)
 
             count = self.count()
 
             return {
                 "meta": {
                     "count": count,
-                    "db_response_time_ms": 0,
-                    "page": 0,
-                    "per_page": 0,
+                    "skip": skip,
+                    "limit": limit,
+                    "result_type": result_type
                 },
                 "results": results,
             }

--- a/app/crud/workstream.py
+++ b/app/crud/workstream.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, List
+from typing import Any, Dict
 
 from neo4j import Driver
 

--- a/app/crud/workstream.py
+++ b/app/crud/workstream.py
@@ -1,13 +1,14 @@
-from typing import Any, Dict
+from typing import Any, Dict, List
 
 from neo4j import Driver
 
 from app.db.session import connect_to_db
+from app.schemas.workstream import WorkstreamBase, WorkstreamModel
 
 
 class Workstream:
     @connect_to_db
-    def get_all(self, db: Driver) -> Dict[str, Any]:
+    def get_all(self, db: Driver) -> List[WorkstreamBase]:
         query = """MATCH (p:Workstream)
                 OPTIONAL MATCH (a:Author)-[:member_of]->(p)
                 RETURN p.id as id, p.name as name, collect(a) as members"""

--- a/app/crud/workstream.py
+++ b/app/crud/workstream.py
@@ -15,10 +15,5 @@ class Workstream:
         return [x.data() for x in records]
 
     @connect_to_db
-    def get(self, id: str, db: Driver) -> Dict[str, Any]:
-        query = """MATCH (p:Workstream)
-                WHERE p.id = $id
-                OPTIONAL MATCH (a:Author)-[:member_of]->(p)
-                RETURN p.id as id, p.name as name, collect(a) as members"""
-        records, summary, keys = db.execute_query(query, id=id)
-        return records[0].data()
+    def get(self, db: Driver, id: str, type) -> Dict[str, Any]:
+        pass

--- a/app/schemas/__init__.py
+++ b/app/schemas/__init__.py
@@ -15,3 +15,8 @@ class AuthorBase(BaseModel):
     last_name: str = Field(..., min_length=1)
     orcid: Optional[HttpUrl] = \
         Field(None, description="Author's ORCID identifier")
+
+
+class CountryBaseModel(BaseModel):
+    id: str
+    name: str

--- a/app/schemas/affiliation.py
+++ b/app/schemas/affiliation.py
@@ -6,4 +6,4 @@ class AffiliationModel(BaseModel):
     id: Optional[str] = None
     name: Optional[str] = None
     ror: Optional[str] = None
-    ccg_partner: bool
+    ccg_partner: Optional[bool] = None

--- a/app/schemas/author.py
+++ b/app/schemas/author.py
@@ -7,7 +7,7 @@ from . import AuthorBase
 from .workstream import WorkstreamBase
 from .affiliation import AffiliationModel
 from .output import OutputListModel
-from .meta import Meta
+from .meta import MetaAuthor
 
 
 class AuthorColabModel(AuthorBase):
@@ -24,7 +24,7 @@ class AuthorListModel(BaseModel):
     A list of authors
     """
     authors: List[AuthorColabModel]
-    meta: Meta
+    meta: MetaAuthor
 
 
 class AuthorOutputModel(AuthorColabModel):

--- a/app/schemas/country.py
+++ b/app/schemas/country.py
@@ -1,20 +1,23 @@
 from typing import Dict, List, Optional
 from pydantic import BaseModel, Field
-
-class CountryModel(BaseModel):
-    """Data model representing country-level research metrics and relationships"""
-
-    outputs: Optional[List] = None
-    authors: Optional[Dict] = None
-    metrics: Optional[Dict] = None
+from . meta import Pagination
+from . output import OutputListModel
+from . import CountryBaseModel
 
 
-class CountryBaseModel(BaseModel):
-    id: str
-    name: str
+class CountryOutputListModel(OutputListModel, CountryBaseModel):
+    """Data model representing country outputs"""
+
+
 
 class CountryNodeModel(CountryBaseModel):
     dbpedia: Optional[str] = None
     latitude: Optional[float] = None
     longitude: Optional[float] = None
     official_name: Optional[str] = None
+
+
+class CountryList(BaseModel):
+
+    meta: Pagination
+    results: list[CountryNodeModel]

--- a/app/schemas/meta.py
+++ b/app/schemas/meta.py
@@ -21,8 +21,16 @@ class CountPublication(BaseModel):
 
 
 class CountAuthor(BaseModel):
-    """Represents a count of the authors"""
+    """Represents a count of the authors or countries"""
     total: int = 0
+
+
+class Pagination(BaseModel):
+    """Used for lists"""
+
+    count: CountAuthor
+    skip: int
+    limit: int
 
 
 class MetaPublication(BaseModel):

--- a/app/schemas/meta.py
+++ b/app/schemas/meta.py
@@ -40,6 +40,9 @@ class MetaPublication(BaseModel):
 
     """
     count: CountPublication | None
+    skip: int
+    limit: int
+    type: str | None
 
 
 class MetaAuthor(BaseModel):
@@ -53,3 +56,5 @@ class MetaAuthor(BaseModel):
 
     """
     count: CountAuthor | None
+    skip: int
+    limit: int

--- a/app/schemas/meta.py
+++ b/app/schemas/meta.py
@@ -1,15 +1,15 @@
 from typing import Dict, List, Optional
-
 from pydantic import BaseModel, Field
+
 
 class CountPublication(BaseModel):
     """Represents count of the outputs
     ```json
         {'total': 245684392,
-        'publication': 1234,
-        'software': 5678,
-        'dataset': 1234,
-        'other': 39494},
+         'publication': 1234,
+         'software': 5678,
+         'dataset': 1234,
+         'other': 39494},
      ```
     """
 
@@ -25,14 +25,31 @@ class CountAuthor(BaseModel):
     total: int = 0
 
 
-class Meta(BaseModel):
+class MetaPublication(BaseModel):
     """
     Base data model representing an academic author or contributor
     with their associated metadata.
 
     ```json
-    "count": {}
+    "count": {'total': 245684392,
+              'publication': 1234,
+              'software': 5678,
+              'dataset': 1234,
+              'other': 39494}
     ```
 
     """
-    count: CountPublication | CountAuthor | None
+    count: CountPublication | None
+
+
+class MetaAuthor(BaseModel):
+    """
+    Base data model representing an academic author or contributor
+    with their associated metadata.
+
+    ```json
+    "count": {'total': 42}
+    ```
+
+    """
+    count: CountAuthor | None

--- a/app/schemas/meta.py
+++ b/app/schemas/meta.py
@@ -42,7 +42,7 @@ class MetaPublication(BaseModel):
     count: CountPublication | None
     skip: int
     limit: int
-    type: str | None
+    result_type: str | None
 
 
 class MetaAuthor(BaseModel):

--- a/app/schemas/output.py
+++ b/app/schemas/output.py
@@ -2,7 +2,7 @@ from pydantic import BaseModel, Field, HttpUrl
 from typing import List, Optional
 from uuid import UUID
 from .author import AuthorBase
-from .country import CountryBaseModel
+from . import CountryBaseModel
 from .meta import MetaPublication
 from .topic import TopicBaseModel
 

--- a/app/schemas/output.py
+++ b/app/schemas/output.py
@@ -3,7 +3,7 @@ from typing import List, Optional
 from uuid import UUID
 from .author import AuthorBase
 from .country import CountryBaseModel
-from .meta import Meta
+from .meta import MetaPublication
 from .topic import TopicBaseModel
 
 
@@ -81,5 +81,5 @@ class OutputListModel(BaseModel):
     """Represents a list of outputs including metadata
 
     """
-    meta: Meta
+    meta: MetaPublication
     results: List[OutputModel]

--- a/app/static/js/map.js
+++ b/app/static/js/map.js
@@ -18,30 +18,30 @@ function draw_map(country) {
 
   var fill
 
-  if (partner_countries.indexOf(country.c.id) >= 0) {
+  if (partner_countries.indexOf(country.id) >= 0) {
     fill = PARTNER_COLOUR
-  } else if (affiliated_countries.indexOf(country.c.id) >= 0) {
+  } else if (affiliated_countries.indexOf(country.id) >= 0) {
     fill = AFFILIATE_COLOUR
-  } else if ((demonstrator_countries.indexOf(country.c.id) >= 0)) {
+  } else if ((demonstrator_countries.indexOf(country.id) >= 0)) {
     fill = DEMONSTRATOR_COLOUR
   } else {
     fill = HIGHLIGHT_COLOUR
   }
   // Above should be replaced with information drawn from the backend database
 
-  const id = "#" + country.c.id;
+  const id = "#" + country.id;
   const svg_map = d3.select(id),
         map_width = +svg_map.attr("width"),
         map_height = +svg_map.attr("height");
 
-  const lat = country.c.latitude;
-  const lon = country.c.longitude;
+  const lat = country.latitude;
+  const lon = country.longitude;
 
   // Load external data and boot
   d3.json("https://raw.githubusercontent.com/holtzy/D3-graph-gallery/master/DATA/world.geojson").then( function(data){
 
       // Filter data
-      country = data.features.filter(d => {console.log(d.properties.name); return d.properties.name==country.c.name})
+      country = data.features.filter(d => {console.log(d.properties.name); return d.properties.name==country.name})
 
     // Initial Map and projection
     const initial_projection = d3.geoMercator()

--- a/app/static/js/world.js
+++ b/app/static/js/world.js
@@ -27,8 +27,6 @@ const projection = d3.geoNaturalEarth1()
     .scale(width / 1.1 / Math.PI)
     .translate([width / 2, height / 2])
 
-const countries = country_data;
-
 // Load external data and draw base map
 d3.json("https://raw.githubusercontent.com/holtzy/D3-graph-gallery/master/DATA/world.geojson").then( function(data) {
 

--- a/app/static/js/world.js
+++ b/app/static/js/world.js
@@ -55,7 +55,7 @@ d3.json("https://raw.githubusercontent.com/holtzy/D3-graph-gallery/master/DATA/w
     }
 
     // Add interactions for CCG output available countries
-    let flat_countries = d3.map(countries, d => d.c.id);
+    let flat_countries = d3.map(countries, d => d.id);
     addCountryInteractions(flat_countries, HIGHLIGHT_COLOUR);
 
     // Add interactions for partner countries

--- a/app/templates/author.html
+++ b/app/templates/author.html
@@ -5,9 +5,9 @@
 <div class="container">
     <div class="row">
         <div class="col">
-            <h1>{{ author.first_name }} {{ author.last_name }}
-            {% if author.orcid %}
-            <a href="{{ author.orcid }}">
+            <h1>{{ first_name }} {{ last_name }}
+            {% if orcid %}
+            <a href="{{ orcid }}">
                 <img alt="ORCID logo" src="https://info.orcid.org/wp-content/uploads/2019/11/orcid_16x16.png" width="24" height="24" />
                 </a>
             {% endif %}
@@ -21,17 +21,17 @@
             <div class="card">
                 <div class="card-body">
                     <!-- Affiliation -->
-                    {% if author.affiliations %}
+                    {% if affiliations %}
                         <h5 class="card-title">Affiliations</h5>
-                        {% for affiliation in author.affiliations %}
+                        {% for affiliation in affiliations %}
                             <span class="badge bg-primary">{{ affiliation.name }}</span>
                         {% endfor %}
                     {% endif %}
                 </div>
                 <div class="card-body">
-                    {% if author.workstreams %}
+                    {% if workstreams %}
                         <h5 class="card-title">Workstreams</h5>
-                        {% for workstream in author.workstreams %}
+                        {% for workstream in workstreams %}
                             <span class="badge bg-secondary">{{ workstream.name }}</span>
                         {% endfor %}
                     {% endif %}
@@ -41,12 +41,12 @@
 
         <div class="col">
             <!-- Collaborators: -->
-            {% if author.collaborators %}
+            {% if collaborators %}
             <div class="card">
                 <div class="card-body">
                     <h5 class="card-title">Top Collaborators for {{ type|title }}</h5>
                     <ul class="list-group list-group-flush">
-                        {% for colab in author.collaborators %}
+                        {% for colab in collaborators %}
                         <li class="list-group-item"><a href="{{ url_for('author', id=colab.uuid) }}">{{ colab.first_name}} {{ colab.last_name }}</a>
                         {% if colab.orcid %}
                             <a href="{{ colab.orcid }}">
@@ -71,7 +71,6 @@
 
         <div class="row">
 
-            {% set outputs = author.outputs.results %}
             {% include 'output_list.j2' %}
 
         </div>

--- a/app/templates/author.html
+++ b/app/templates/author.html
@@ -70,7 +70,8 @@
         </div>
 
         <div class="row">
-
+            {% set results = outputs.results %}
+            {% set meta = outputs.meta %}
             {% include 'output_list.j2' %}
 
         </div>

--- a/app/templates/authors.html
+++ b/app/templates/authors.html
@@ -23,29 +23,6 @@
     </div>
     {% endfor %}
 
-    <div class="row">
-        <nav aria-label="Page navigation example">
-        <ul class="pagination justify-content-center">
-            {% if not skip == 0%}
-            <li class="page-item"><a class="page-link" href="?limit={{meta.limit}}&skip={{meta.skip - meta.limit}}">Previous</a></li>
-            {% endif %}
-
-            {% if meta.count.total %}
-            {% for page in range((meta.count.total // meta.limit) + 1) %}
-                {% set skipper = (page) * meta.limit %}
-                {% if skipper == meta.skip %}
-                    <li class="page-item"><a class="page-link active" href="?limit={{meta.limit}}&skip={{skipper}}">{{ page + 1 }}</a></li>
-                {% else %}
-                    <li class="page-item"><a class="page-link" href="?limit={{meta.limit}}&skip={{skipper}}">{{ page + 1 }}</a></li>
-                {% endif%}
-            {% endfor %}
-
-            {% if not meta.skip >= meta.count.total - meta.limit %}
-            <li class="page-item"><a class="page-link" href="?limit={{meta.limit}}&skip={{meta.skip + meta.limit}}">Next</a></li>
-            {% endif %}
-            {% endif %}
-        </ul>
-        </nav>
-    </div>
+{% include 'pagination.html' %}
 
 {% endblock %}

--- a/app/templates/authors.html
+++ b/app/templates/authors.html
@@ -27,21 +27,21 @@
         <nav aria-label="Page navigation example">
         <ul class="pagination justify-content-center">
             {% if not skip == 0%}
-            <li class="page-item"><a class="page-link" href="?limit={{limit}}&skip={{skip - limit}}">Previous</a></li>
+            <li class="page-item"><a class="page-link" href="?limit={{meta.limit}}&skip={{meta.skip - meta.limit}}">Previous</a></li>
             {% endif %}
 
-            {% if count %}
-            {% for page in range((count // limit) + 1) %}
-                {% set skipper = (page) * limit %}
-                {% if skipper == skip %}
-                    <li class="page-item"><a class="page-link active" href="?limit={{limit}}&skip={{skipper}}">{{ page + 1 }}</a></li>
+            {% if meta.count.total %}
+            {% for page in range((meta.count.total // meta.limit) + 1) %}
+                {% set skipper = (page) * meta.limit %}
+                {% if skipper == meta.skip %}
+                    <li class="page-item"><a class="page-link active" href="?limit={{meta.limit}}&skip={{skipper}}">{{ page + 1 }}</a></li>
                 {% else %}
-                    <li class="page-item"><a class="page-link" href="?limit={{limit}}&skip={{skipper}}">{{ page + 1 }}</a></li>
+                    <li class="page-item"><a class="page-link" href="?limit={{meta.limit}}&skip={{skipper}}">{{ page + 1 }}</a></li>
                 {% endif%}
             {% endfor %}
 
-            {% if not skip >= count - limit %}
-            <li class="page-item"><a class="page-link" href="?limit={{limit}}&skip={{skip + limit}}">Next</a></li>
+            {% if not meta.skip >= meta.count.total - meta.limit %}
+            <li class="page-item"><a class="page-link" href="?limit={{meta.limit}}&skip={{meta.skip + meta.limit}}">Next</a></li>
             {% endif %}
             {% endif %}
         </ul>

--- a/app/templates/country.html
+++ b/app/templates/country.html
@@ -4,7 +4,7 @@
 
 <div class="container" id="research_products">
 
-<h1>{{ country.name }}</h1>
+<h1>{{ name }}</h1>
 
 {% include 'output_list.j2' %}
 

--- a/app/templates/country_list.html
+++ b/app/templates/country_list.html
@@ -9,7 +9,7 @@
 </div>
 <div class="row">
     <div class="row">
-        {% for country in countries %}
+        {% for country in results %}
             <div class="col-sm">
                 <div id="card-{{country.id}}" class="card">
                     <svg id="{{country.id}}" width="320" height="240"></svg>
@@ -22,9 +22,12 @@
         {% endfor %}
         <script src="{{url_for('static', path='js/map.js')}}"></script>
         <script>
-          let countries = {{countries|tojson}};
+          let countries = {{results|tojson}};
           countries.forEach(draw_map);
         </script>
     </div>
 </div>
+
+{% include 'pagination.html' %}
+
 {% endblock %}

--- a/app/templates/country_list.html
+++ b/app/templates/country_list.html
@@ -19,7 +19,7 @@
                 </div>
             </div>
         {% endfor %}
-        <script src="{{url_for('static', path='js/map.js', _external=True, _scheme='https')}}"></script>
+        <script src="{{url_for('static', path='js/map.js')}}"></script>
         <script>
           let countries = {{countries|tojson}};
           countries.forEach(draw_map);

--- a/app/templates/country_list.html
+++ b/app/templates/country_list.html
@@ -1,6 +1,7 @@
 {% extends "base.html" %}
 
 {% block content %}
+
 <div class="row">
     <div class="col">
       <h4>CCG works in the following countries</h4>
@@ -10,12 +11,12 @@
     <div class="row">
         {% for country in countries %}
             <div class="col-sm">
-                <div id="card-{{country.c.id}}" class="card">
-                    <svg id="{{country.c.id}}" width="320" height="240"></svg>
+                <div id="card-{{country.id}}" class="card">
+                    <svg id="{{country.id}}" width="320" height="240"></svg>
                         <div class="card-body">
-                        <h5 class="card-title">{{country.c.name}}</h5>
+                        <h5 class="card-title">{{country.name}}</h5>
                         </div>
-                    <a href="{{ url_for('country', id=country.c.id) }}" role="button" class="btn btn-primary">View Outputs</a>
+                    <a href="{{ url_for('country', id=country.id) }}" role="button" class="btn btn-primary">View Outputs</a>
                 </div>
             </div>
         {% endfor %}

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -1,7 +1,6 @@
 {% extends "base.html" %}
 
 {% block content %}
-
 <style>
 
 .links line {
@@ -34,7 +33,7 @@
           <h4>CCG works in the following countries</h4>
           <svg id="my_dataviz" class="figure-img img-fluid" width="800" height="600"></svg>
           <script>
-            let country_data = {{countries|tojson}};
+            let country_data = {{ countries|tojson }};
           </script>
             <script src="{{url_for('static', path='js/world.js')}}" type="module">
           </script>

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -33,7 +33,7 @@
           <h4>CCG works in the following countries</h4>
           <svg id="my_dataviz" class="figure-img img-fluid" width="800" height="600"></svg>
           <script>
-            let country_data = {{ countries|tojson }};
+            let countries = {{ results|tojson }};
           </script>
             <script src="{{url_for('static', path='js/world.js')}}" type="module">
           </script>

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -36,7 +36,7 @@
           <script>
             let country_data = {{countries|tojson}};
           </script>
-            <script src="{{url_for('static', path='js/world.js', _external=True, _scheme='https')}}" type="module">
+          <script src="{{url_for('static', path='js/world.js')}}" type="module">
           </script>
     </div>
   </div>

--- a/app/templates/output.html
+++ b/app/templates/output.html
@@ -8,20 +8,20 @@
 <div class="container">
     <div class="row">
         <div class="col">
-            {% if output.result_type %}
-                <span class="badge text-bg-secondary">{{ output.result_type }}</span>
+            {% if result_type %}
+                <span class="badge text-bg-secondary">{{ result_type }}</span>
             {% endif %}
-            <h1>{{ output.title }}</h1>
+            <h1>{{ title }}</h1>
         </div>
     </div>
     <div class="row">
         <div class="col">
-            {%if output.countries %}
+            {%if countries %}
             <div class="col">
                 <div class="card">
                     <div class="card-body">
                             <h5 class="card-title">Countries</h5>
-                            {% for country in output.countries %}
+                            {% for country in countries %}
                             <a href="{{ url_for('country', id=country.id) }}" class="badge text-bg-danger">{{ country.name }}</a>
                             {% endfor %}
                     </div>
@@ -32,9 +32,9 @@
                 <div class="card">
                     <div class="card-body">
                         <h5 class="card-title">Metadata</h5>
-                            {% if output.publication_year %}<b>Publication Year: </b>{{ output.publication_year }}{% endif %}
-                            {% if output.journal%}<p></p><b>Journal: </b>{{ output.journal }}</p>{% endif %}
-                        <a href="http://doi.org/{{ output.doi }}">http://doi.org/{{ output.doi }}</a>
+                            {% if publication_year %}<b>Publication Year: </b>{{ publication_year }}{% endif %}
+                            {% if journal%}<p></p><b>Journal: </b>{{ journal }}</p>{% endif %}
+                        <a href="http://doi.org/{{ doi }}">http://doi.org/{{ doi }}</a>
                     </div>
                 </div>
             </div>
@@ -44,8 +44,8 @@
             <div class="card">
                 <div class="card-body">
                     <h5 class="card-title">Metrics</h5>
-                        <span class="__dimensions_badge_embed__" data-doi="{{ output.doi }}" data-style="small_circle" data-legend="always"></span>
-                        <span class='altmetric-embed' data-badge-type='donut' data-badge-details='right' data-doi="{{ output.doi }}"></span>
+                        <span class="__dimensions_badge_embed__" data-doi="{{ doi }}" data-style="small_circle" data-legend="always"></span>
+                        <span class='altmetric-embed' data-badge-type='donut' data-badge-details='right' data-doi="{{ doi }}"></span>
 
                 </div>
             </div>
@@ -55,7 +55,7 @@
             <div class="card">
                 <div class="card-body">
                     <h5 class="card-title">Authors</h5>
-                    {% for author in output.authors %}
+                    {% for author in authors %}
                         <l><a href="{{ url_for('author', id=author.uuid) }}">{{ author.first_name}} {{ author.last_name }}</a>
                         {% if author.orcid %}
                             <a href="{{ author.orcid }}"><img alt="ORCID logo" src="https://info.orcid.org/wp-content/uploads/2019/11/orcid_16x16.png" width="16" height="16" /></a>
@@ -72,7 +72,7 @@
             <div class="card">
                 <div class="card-body">
                     <h5 class="card-title">Abstract</h5>
-                    {{ output.abstract }}
+                    {{ abstract }}
                 </div>
             </div>
         </div>

--- a/app/templates/output_list.j2
+++ b/app/templates/output_list.j2
@@ -1,10 +1,10 @@
 <div class="row">
     <h5>Filter by result type: </h5>
     <div class="btn-group" id="filter_button" role="group" aria-label="Filter research type">
-    {% for type in ['publication', 'dataset', 'software', 'other'] %}
-        <a href="?type={{ type }}&limit={{limit}}&skip=0" class="btn btn-primary">
-            {{type}}
-            <span class="badge text-bg-secondary">{{count[type]|default(0)}}</span>
+    {% for result_type in ['publication', 'dataset', 'software', 'other'] %}
+        <a href="?result_type={{ result_type }}&limit={{limit}}&skip=0" class="btn btn-primary">
+            {{result_type}}
+            <span class="badge text-bg-secondary">{{count[result_type]|default(0)}}</span>
             </a>
     {% endfor %}
     </div>
@@ -53,21 +53,21 @@
     <nav aria-label="Page navigation">
     <ul class="pagination justify-content-center">
         {% if not skip == 0%}
-        <li class="page-item"><a class="page-link" href="?type={{ type }}&limit={{limit}}&skip={{skip - limit}}">Previous</a></li>
+        <li class="page-item"><a class="page-link" href="?result_type={{ result_type }}&limit={{limit}}&skip={{skip - limit}}">Previous</a></li>
         {% endif %}
 
-        {% if count[type] %}
-        {% for page in range((count[type] // limit) + 1) %}
+        {% if count[result_type] %}
+        {% for page in range((count[result_type] // limit) + 1) %}
             {% set skipper = (page) * limit %}
             {% if skipper == skip %}
-                <li class="page-item"><a class="page-link active" href="?type={{ type }}&limit={{limit}}&skip={{skipper}}">{{ page + 1 }}</a></li>
+                <li class="page-item"><a class="page-link active" href="?result_type={{ result_type }}&limit={{limit}}&skip={{skipper}}">{{ page + 1 }}</a></li>
             {% else %}
-                <li class="page-item"><a class="page-link" href="?type={{ type }}&limit={{limit}}&skip={{skipper}}">{{ page + 1 }}</a></li>
+                <li class="page-item"><a class="page-link" href="?result_type={{ result_type }}&limit={{limit}}&skip={{skipper}}">{{ page + 1 }}</a></li>
             {% endif%}
         {% endfor %}
 
-        {% if not skip >= count[type] - limit %}
-        <li class="page-item"><a class="page-link" href="?type={{ type }}&limit={{limit}}&skip={{skip + limit}}">Next</a></li>
+        {% if not skip >= count[result_type] - limit %}
+        <li class="page-item"><a class="page-link" href="?result_type={{ result_type }}&limit={{limit}}&skip={{skip + limit}}">Next</a></li>
         {% endif %}
         {% endif %}
     </ul>

--- a/app/templates/output_list.j2
+++ b/app/templates/output_list.j2
@@ -2,17 +2,17 @@
     <h5>Filter by result type: </h5>
     <div class="btn-group" id="filter_button" role="group" aria-label="Filter research type">
     {% for result_type in ['publication', 'dataset', 'software', 'other'] %}
-        <a href="?result_type={{ result_type }}&limit={{limit}}&skip=0" class="btn btn-primary">
+        <a href="?result_type={{ result_type }}&limit={{outputs.meta.limit|default(20)}}&skip=0" class="btn btn-primary">
             {{result_type}}
-            <span class="badge text-bg-secondary">{{count[result_type]|default(0)}}</span>
+            <span class="badge text-bg-secondary">{{outputs.meta.count[result_type]|default(0)}}</span>
             </a>
     {% endfor %}
     </div>
 </div>
 
 <div class="row">
-    {% if outputs %}
-        {% for output in outputs %}
+    {% if outputs.results %}
+        {% for output in outputs.results %}
             <div class="card" id="{{output.uuid}}">
                 <div class="card-body">
                     <h5 class="card-title">{{ output.title }}
@@ -49,14 +49,19 @@
     {% endif %}
 </div>
 
+{% set result_type = outputs.meta.result_type|default(publication) %}
+{% set limit = outputs.meta.limit %}
+{% set skip = outputs.meta.skip %}
+{% set count = outputs.meta.count %}
+
 <div class="row">
     <nav aria-label="Page navigation">
     <ul class="pagination justify-content-center">
-        {% if not skip == 0%}
+        {% if skip > 0 %}
         <li class="page-item"><a class="page-link" href="?result_type={{ result_type }}&limit={{limit}}&skip={{skip - limit}}">Previous</a></li>
         {% endif %}
 
-        {% if count[result_type] %}
+        {% if count[result_type] > 0 %}
         {% for page in range((count[result_type] // limit) + 1) %}
             {% set skipper = (page) * limit %}
             {% if skipper == skip %}

--- a/app/templates/output_list.j2
+++ b/app/templates/output_list.j2
@@ -2,17 +2,17 @@
     <h5>Filter by result type: </h5>
     <div class="btn-group" id="filter_button" role="group" aria-label="Filter research type">
     {% for result_type in ['publication', 'dataset', 'software', 'other'] %}
-        <a href="?result_type={{ result_type }}&limit={{outputs.meta.limit|default(20)}}&skip=0" class="btn btn-primary">
+        <a href="?result_type={{ result_type }}&limit={{meta.limit|default(20)}}&skip=0" class="btn btn-primary">
             {{result_type}}
-            <span class="badge text-bg-secondary">{{outputs.meta.count[result_type]|default(0)}}</span>
+            <span class="badge text-bg-secondary">{{meta.count[result_type]|default(0)}}</span>
             </a>
     {% endfor %}
     </div>
 </div>
 
 <div class="row">
-    {% if outputs.results %}
-        {% for output in outputs.results %}
+    {% if results %}
+        {% for output in results %}
             <div class="card" id="{{output.uuid}}">
                 <div class="card-body">
                     <h5 class="card-title">{{ output.title }}
@@ -49,10 +49,10 @@
     {% endif %}
 </div>
 
-{% set result_type = outputs.meta.result_type|default(publication) %}
-{% set limit = outputs.meta.limit %}
-{% set skip = outputs.meta.skip %}
-{% set count = outputs.meta.count %}
+{% set result_type = meta.result_type|default(publication) %}
+{% set limit = meta.limit %}
+{% set skip = meta.skip %}
+{% set count = meta.count %}
 
 <div class="row">
     <nav aria-label="Page navigation">

--- a/main.py
+++ b/main.py
@@ -84,15 +84,14 @@ def author(request: Request,
            type: str = 'publication',
            skip: int = 0,
            limit: int = 20):
-    author_model = Author()
-    entity = author_model.get(id, result_type=type, skip=skip, limit=limit)
-    count = author_model.count(id)
+    author = Author()
+    entity = author.get_author(id, type=type, skip=skip, limit=limit)
     return templates.TemplateResponse(
         "author.html",
         {"request": request,
          "title": "Author",
          "author": entity,
-         "count": count,
+         "count":  entity['outputs']['meta']['count']['total'],
          "skip": skip,
          "limit": limit,
          'type': type},
@@ -101,16 +100,15 @@ def author(request: Request,
 
 @app.get("/authors", response_class=HTMLResponse)
 def author_list(request: Request, skip: int = 0, limit: int = 20):
-    model = Author()
-    entity = model.get_all(skip=skip, limit=limit)
-    count = model.count_authors()
+    authors = Author()
+    entity= authors.get_authors(skip=skip, limit=limit)
     return templates.TemplateResponse(
         "authors.html", {"request": request,
                          "title": "Author List",
-                         "authors": entity,
+                         "authors": entity['authors'],
                          "skip": skip,
                          "limit": limit,
-                         "count": count}
+                         "count": entity['meta']['count']['total']}
     )
 
 

--- a/main.py
+++ b/main.py
@@ -85,16 +85,14 @@ def author(request: Request,
            skip: int = 0,
            limit: int = 20):
     author = Author()
-    entity = author.get_author(id, result_type=result_type, skip=skip, limit=limit)
+    entity = author.get_author(id,
+                               result_type=result_type,
+                               skip=skip,
+                               limit=limit)
     return templates.TemplateResponse(
         "author.html",
         {"request": request,
-         "title": "Author",
-         "author": entity,
-         "count":  entity['outputs']['meta']['count'],
-         "skip": skip,
-         "limit": limit,
-         'result_type': result_type},
+         "title": "Author"} | entity
     )
 
 
@@ -104,11 +102,7 @@ def author_list(request: Request, skip: int = 0, limit: int = 20):
     entity = authors.get_authors(skip=skip, limit=limit)
     return templates.TemplateResponse(
         "authors.html", {"request": request,
-                         "title": "Author List",
-                         "authors": entity['authors'],
-                         "skip": skip,
-                         "limit": limit,
-                         "count": entity['meta']['count']['total']}
+                         "title": "Author List"} | entity  # Merges dicts
     )
 
 
@@ -124,12 +118,7 @@ def output_list(request: Request,
     return templates.TemplateResponse(
         "outputs.html",
         {"request": request,
-         "title": "Output List",
-         "outputs": package['results'],
-         "count": package['meta']['count'],
-         "result_type": result_type,
-         "skip": skip,
-         "limit": limit}
+         "title": "Output List"} | package
     )
 
 

--- a/main.py
+++ b/main.py
@@ -92,7 +92,7 @@ def author(request: Request,
     return templates.TemplateResponse(
         "author.html",
         {"request": request,
-         "title": "Author"} | entity
+         "title": "Author"} | entity  # Merges dicts
     )
 
 

--- a/main.py
+++ b/main.py
@@ -120,26 +120,7 @@ def output_list(request: Request,
                 country: str = None):
 
     model = Output()
-    if country:
-        results = model.filter_country(result_type=type,
-                                       skip=skip,
-                                       limit=limit,
-                                       country=country)
-    else:
-        results = model.filter_type(result_type=type,
-                                    skip=skip,
-                                    limit=limit)
-
-    count = model.count()
-
-    package = {
-        "meta": {"count": count,
-                 "db_response_time_ms": 0,
-                 "page": 0,
-                 "per_page": 0},
-        "results": results
-    }
-
+    package = model.get_outputs(skip=skip, limit=limit, type=type, country=country)
     return templates.TemplateResponse(
         "outputs.html",
         {"request": request,
@@ -155,6 +136,6 @@ def output_list(request: Request,
 @app.get("/outputs/{id}", response_class=HTMLResponse)
 def output(request: Request, id: str):
     output_model = Output()
-    entity = output_model.get(id)
+    entity = output_model.get_output(id)
     return templates.TemplateResponse(
         "output.html", {"request": request, "title": "Output", "output": entity})

--- a/main.py
+++ b/main.py
@@ -127,4 +127,4 @@ def output(request: Request, id: str):
     output_model = Output()
     entity = output_model.get_output(id)
     return templates.TemplateResponse(
-        "output.html", {"request": request, "title": "Output", "output": entity})
+        "output.html", {"request": request, "title": "Output"} | entity )

--- a/main.py
+++ b/main.py
@@ -1,5 +1,3 @@
-from typing import List
-
 from fastapi import FastAPI, Request
 from fastapi.responses import HTMLResponse
 from fastapi.staticfiles import StaticFiles
@@ -9,15 +7,19 @@ from app.crud.author import Author
 from app.crud.country import Country
 from app.crud.graph import Edges, Nodes
 from app.crud.output import Output
-from app.crud.workstream import Workstream
 
-from app.schemas.author import AuthorModel, AuthorListModel
-from app.schemas.country import CountryNodeModel
-from app.schemas.output import OutputModel, OutputListModel
-from app.schemas.workstream import WorkstreamBase, WorkstreamModel
-from app.schemas.topic import TopicBaseModel
+from app.api import author, output, country, workstream
 
 app = FastAPI()
+
+app.mount("/static", StaticFiles(directory="app/static"), name="static")
+
+templates = Jinja2Templates(directory="app/templates")
+
+app.include_router(author.router)
+app.include_router(output.router)
+app.include_router(country.router)
+app.include_router(workstream.router)
 
 templates = Jinja2Templates(directory="app/templates")
 app.mount("/static", StaticFiles(directory="app/static"), name="static")
@@ -108,119 +110,4 @@ def output(request: Request, id: str):
     output_model = Output()
     entity = output_model.get(id)
     return templates.TemplateResponse(
-        "output.html", {"request": request, "title": "Output", "output": entity}
-    )
-
-
-@app.get("/api/authors/{id}")
-def api_author(id: str, type: str = None) -> AuthorModel:
-    author_model = Author()
-    results = author_model.get(id, result_type=type)
-    count = author_model.count(id)
-    results['outputs']['meta'] = {"count": count,
-                                  "db_response_time_ms": 0,
-                                  "page": 0,
-                                  "per_page": 0}
-
-    return results
-
-
-@app.get("/api/authors")
-def api_author_list(skip: int = 0, limit: int = 20) -> List[AuthorListModel]:
-    model = Author()
-    return model.get_all(skip=skip, limit=limit)
-
-
-@app.get("/api/countries/{id}")
-def api_country(id: str, type: str = None)-> OutputListModel:
-    """Return a list of outputs filtered by the country id provided
-
-    Arguments
-    ---------
-    id: str
-        The 3-letter ISO country code
-    type: str
-        One of "dataset", "publication", "tools", "other"
-
-    Returns
-    -------
-    OutputListModel schema
-
-    """
-    country_model = Country()
-    outputs, country = country_model.get(id, result_type=type)
-    count = country_model.count(id)
-    return {"outputs": outputs, "country": country, "count": count}
-
-
-@app.get("/api/countries")
-def api_country_list()-> List[CountryNodeModel]:
-    country_model = Country()
-    results = country_model.get_all()
-    return [result['c'] for result in results] # The queries should return a list of dictionaries, each containing a 'c' key with the country information
-                                               # This is a temporary workaround but the queries should be updated to return the correct data structure
-
-
-@app.get("/api/outputs")
-def api_output_list(skip: int = 0,
-                    limit: int = 20,
-                    type: str = 'publication',
-                    country: str = None) -> OutputListModel:
-    """Return a list of outputs
-
-    Arguments
-    ---------
-    skip: int, default = 0
-    limit: int, default = 20
-    type: enum, default = None
-    country: str, default = None
-    """
-    model = Output()
-    if country:
-        results = model.filter_country(result_type=type,
-                                       skip=skip,
-                                       limit=limit,
-                                       country=country)
-    else:
-        results = model.filter_type(result_type=type,
-                                    skip=skip,
-                                    limit=limit)
-
-    count = model.count()
-
-    return {
-        "meta": {"count": count,
-                 "db_response_time_ms": 0,
-                 "page": 0,
-                 "per_page": 0},
-        "results": results
-    }
-
-
-@app.get("/api/outputs/{id}")
-def api_output(id: str) -> OutputModel:
-    output_model = Output()
-    results = output_model.get(id)
-    return results
-
-
-@app.get("/api/workstreams")
-def api_workstream_list() -> List[WorkstreamBase]:
-    model = Workstream()
-    return model.get_all()
-
-
-@app.get("/api/workstreams/{id}")
-def api_workstream(id: str) -> WorkstreamModel:
-    model = Workstream()
-    return model.get(id)
-
-
-@app.get("api/topics")
-def api_topics_list() -> List[TopicBaseModel]:
-    raise NotImplementedError("Have not yet implemented topics in the database")
-
-
-@app.get("api/topics/{id}")
-def api_topics_list(id: str) -> TopicBaseModel:
-    raise NotImplementedError("Have not yet implemented topics in the database")
+        "output.html", {"request": request, "title": "Output", "output": entity})

--- a/main.py
+++ b/main.py
@@ -51,8 +51,8 @@ def country(request: Request,
                                            country=id,
                                            skip=skip,
                                            limit=limit)
-    country = country_model.get(id)
-    count = country_model.count(id)
+    country = country_model.fetch_country_node(id)
+    count = country_model.count_country_outputs(id)
     return templates.TemplateResponse(
         "country.html",
         {
@@ -71,7 +71,7 @@ def country(request: Request,
 @app.get("/countries", response_class=HTMLResponse)
 def country_list(request: Request):
     country_model = Country()
-    entity = country_model.get_all()
+    entity = country_model.get_countries()
     return templates.TemplateResponse(
         "country_list.html",
         {"request": request, "title": "Countries", "countries": entity},
@@ -91,7 +91,7 @@ def author(request: Request,
         {"request": request,
          "title": "Author",
          "author": entity,
-         "count":  entity['outputs']['meta']['count']['total'],
+         "count":  entity['outputs']['meta']['count'],
          "skip": skip,
          "limit": limit,
          'type': type},
@@ -101,7 +101,7 @@ def author(request: Request,
 @app.get("/authors", response_class=HTMLResponse)
 def author_list(request: Request, skip: int = 0, limit: int = 20):
     authors = Author()
-    entity= authors.get_authors(skip=skip, limit=limit)
+    entity = authors.get_authors(skip=skip, limit=limit)
     return templates.TemplateResponse(
         "authors.html", {"request": request,
                          "title": "Author List",

--- a/main.py
+++ b/main.py
@@ -26,7 +26,7 @@ app.mount("/static", StaticFiles(directory="app/static"), name="static")
 def index(request: Request):
     nodes = Nodes().get()
     edges = Edges().get()
-    countries = Country().get_all()
+    countries = Country().get_countries()
     return templates.TemplateResponse(
         "index.html",
         {
@@ -42,12 +42,12 @@ def index(request: Request):
 @app.get("/countries/{id}", response_class=HTMLResponse)
 def country(request: Request,
             id: str,
-            type: str = 'publication',
+            result_type: str = 'publication',
             skip: int = 0,
             limit: int = 20):
     country_model = Country()
     outputs_model = Output()
-    outputs = outputs_model.filter_country(result_type=type,
+    outputs = outputs_model.filter_country(result_type=result_type,
                                            country=id,
                                            skip=skip,
                                            limit=limit)
@@ -63,7 +63,7 @@ def country(request: Request,
             "count": count,
             "skip": skip,
             "limit": limit,
-            "type": type
+            "result_type": result_type
         },
     )
 
@@ -81,11 +81,11 @@ def country_list(request: Request):
 @app.get("/authors/{id}", response_class=HTMLResponse)
 def author(request: Request,
            id: str,
-           type: str = 'publication',
+           result_type: str = 'publication',
            skip: int = 0,
            limit: int = 20):
     author = Author()
-    entity = author.get_author(id, type=type, skip=skip, limit=limit)
+    entity = author.get_author(id, result_type=result_type, skip=skip, limit=limit)
     return templates.TemplateResponse(
         "author.html",
         {"request": request,
@@ -94,7 +94,7 @@ def author(request: Request,
          "count":  entity['outputs']['meta']['count'],
          "skip": skip,
          "limit": limit,
-         'type': type},
+         'result_type': result_type},
     )
 
 
@@ -114,20 +114,20 @@ def author_list(request: Request, skip: int = 0, limit: int = 20):
 
 @app.get("/outputs", response_class=HTMLResponse)
 def output_list(request: Request,
-                type: str = 'publication',
+                result_type: str = 'publication',
                 skip: int = 0,
                 limit: int = 20,
                 country: str = None):
 
     model = Output()
-    package = model.get_outputs(skip=skip, limit=limit, type=type, country=country)
+    package = model.get_outputs(skip=skip, limit=limit, result_type=result_type, country=country)
     return templates.TemplateResponse(
         "outputs.html",
         {"request": request,
          "title": "Output List",
          "outputs": package['results'],
          "count": package['meta']['count'],
-         "type": type,
+         "result_type": result_type,
          "skip": skip,
          "limit": limit}
     )

--- a/main.py
+++ b/main.py
@@ -9,17 +9,8 @@ from app.crud.graph import Edges, Nodes
 from app.crud.output import Output
 
 from app.api import author, output, country, workstream
-from app.schemas.author import AuthorListModel, AuthorOutputModel
-from app.schemas.country import CountryNodeModel
-from app.schemas.output import OutputModel, OutputListModel
-from app.schemas.workstream import WorkstreamBase, WorkstreamModel
-from app.schemas.topic import TopicBaseModel
 
 app = FastAPI()
-
-app.mount("/static", StaticFiles(directory="app/static"), name="static")
-
-templates = Jinja2Templates(directory="app/templates")
 
 app.include_router(author.router)
 app.include_router(output.router)

--- a/main.py
+++ b/main.py
@@ -24,20 +24,12 @@ app.mount("/static", StaticFiles(directory="app/static"), name="static")
 @app.get("/", response_class=HTMLResponse)
 @app.get("/index", response_class=HTMLResponse)
 def index(request: Request):
-    nodes = Nodes().get()
-    edges = Edges().get()
-    countries = Country().get_countries()
+    countries = Country().get_countries(skip=0, limit=200)
     return templates.TemplateResponse(
         "index.html",
-        {
-            "request": request,
-            "title": "Home",
-            "nodes": nodes,
-            "links": edges,
-            "countries": countries,
-        },
+        {"request": request,
+         "title": "Home"} | countries
     )
-
 
 @app.get("/countries/{id}", response_class=HTMLResponse)
 def country(request: Request,
@@ -46,35 +38,24 @@ def country(request: Request,
             skip: int = 0,
             limit: int = 20):
     country_model = Country()
-    outputs_model = Output()
-    outputs = outputs_model.filter_country(result_type=result_type,
-                                           country=id,
-                                           skip=skip,
-                                           limit=limit)
-    country = country_model.fetch_country_node(id)
-    count = country_model.count_country_outputs(id)
+    country = country_model.get_country(id, skip, limit, result_type)
     return templates.TemplateResponse(
         "country.html",
         {
             "request": request,
-            "title": "Country",
-            "outputs": outputs,
-            "country": country,
-            "count": count,
-            "skip": skip,
-            "limit": limit,
-            "result_type": result_type
-        },
+            "title": "Country"} | country
     )
 
 
 @app.get("/countries", response_class=HTMLResponse)
-def country_list(request: Request):
+def country_list(request: Request,
+                 skip: int = 0,
+                 limit: int = 20):
     country_model = Country()
-    entity = country_model.get_countries()
+    entity = country_model.get_countries(skip, limit)
     return templates.TemplateResponse(
         "country_list.html",
-        {"request": request, "title": "Countries", "countries": entity},
+        {"request": request, "title": "Countries"} | entity
     )
 
 
@@ -114,7 +95,10 @@ def output_list(request: Request,
                 country: str = None):
 
     model = Output()
-    package = model.get_outputs(skip=skip, limit=limit, result_type=result_type, country=country)
+    package = model.get_outputs(skip=skip,
+                                limit=limit,
+                                result_type=result_type,
+                                country=country)
     return templates.TemplateResponse(
         "outputs.html",
         {"request": request,
@@ -127,4 +111,5 @@ def output(request: Request, id: str):
     output_model = Output()
     entity = output_model.get_output(id)
     return templates.TemplateResponse(
-        "output.html", {"request": request, "title": "Output"} | entity )
+        "output.html",
+        {"request": request, "title": "Output"} | entity )


### PR DESCRIPTION
- removed non-working fix for HTTP serving of static files.
- Moved API endpoints to individual routes
- Merged pagination branch
- Refactored API endpoints moving most logic to app/crud.py.
- Annotated crud methods with the corresponding response schema wherever appropriate.

Action Items
-------------------------------------------------------------------------------------------------------
- [x] Update view endpoints to align with the new implementation.
- [x] If Fetch country by ID endpoint is to be kept, it requires a better schema to be defined for the return type. 