### PR TITLE
Fix: Allow cited_by_count_date to accept integer values

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,6 @@ build/
 research_index_backend/
 data/
 *.bash
+
+# quick deployment zip file
+app.zip

--- a/app/schemas/output.py
+++ b/app/schemas/output.py
@@ -40,7 +40,7 @@ class OutputModel(BaseModel):
         "title": 'An example title', # required
         "abstract": 'A long abstract', # optional
         "journal": "Applied JSON", # optional
-        "cited_by_count_date": '2024-03-01', # optional
+        "cited_by_count_date": 2026, # optional (year as integer)
         "cited_by_count": 34, # optional
         "openalex": "https://openalex.org/W4393416420", # optional
         "publication_day": 03, # optional

--- a/app/schemas/output.py
+++ b/app/schemas/output.py
@@ -6,28 +6,6 @@ from . import CountryBaseModel
 from .meta import MetaPublication
 from .topic import TopicBaseModel
 
-
-class DateTimeComponents(BaseModel):
-    _Date__ordinal: Optional[int] = None
-    _Date__year: Optional[int] = None
-    _Date__month: Optional[int] = None
-    _Date__day: Optional[int] = None
-
-
-class TimeComponents(BaseModel):
-    _Time__ticks: Optional[int] = None
-    _Time__hour: Optional[int] = None
-    _Time__minute: Optional[int] = None
-    _Time__second: Optional[int] = None
-    _Time__nanosecond: Optional[int] = None
-    _Time__tzinfo: Optional[str] = None
-
-
-class CitedByDateTime(BaseModel):
-    _DateTime__date: Optional[DateTimeComponents] = None
-    _DateTime__time: Optional[TimeComponents] = None
-
-
 class OutputModel(BaseModel):
     """Schema for an Output
 
@@ -67,7 +45,7 @@ class OutputModel(BaseModel):
     authors: List[AuthorBase]
     abstract: Optional[str] = None
     journal: Optional[str] = None  # Only academic publications have a journal
-    cited_by_count_date: Optional[CitedByDateTime | int] = None
+    cited_by_count_date: Optional[int] = Field(default=None, ge=1900, le=2100, description="Year in YYYY format")
     cited_by_count: Optional[int] = None
     publication_day: Optional[int] = None
     publication_month: Optional[int] = None

--- a/app/schemas/output.py
+++ b/app/schemas/output.py
@@ -67,7 +67,7 @@ class OutputModel(BaseModel):
     authors: List[AuthorBase]
     abstract: Optional[str] = None
     journal: Optional[str] = None  # Only academic publications have a journal
-    cited_by_count_date: Optional[CitedByDateTime] = None
+    cited_by_count_date: Optional[CitedByDateTime | int] = None
     cited_by_count: Optional[int] = None
     publication_day: Optional[int] = None
     publication_month: Optional[int] = None


### PR DESCRIPTION
**Title:** Fix: Allow `cited_by_count_date` to accept integer values

***Update:*** 
- Removed unused `DateTimeComponents`, `TimeComponents`, and `CitedByDateTime` classes
- Simplified `cited_by_count_date` to `Optional[int]` with validation enforcing `YYYY` format (1900-2100)

**Description:**

## Problem

The `/api/countries/{id}` endpoint was returning 500 Internal Server Error for countries with publication data (e.g., `/api/countries/KEN`).

The error was:
```
fastapi.exceptions.ResponseValidationError: 6 validation errors:
  {'type': 'model_attributes_type', 'loc': ('response', 'results', 0, 'cited_by_count_date'), 
   'msg': 'Input should be a valid dictionary or object to extract fields from', 'input': 2026}
```

## Cause

The `cited_by_count_date` field in the Pydantic model (`OutputModel`) only accepted `CitedByDateTime` objects, but the Memgraph database stores this field as an integer year (e.g., `2026`).

## Solution

- Removed unused `DateTimeComponents`, `TimeComponents`, and `CitedByDateTime` classes
- Simplified `cited_by_count_date` to `Optional[int]` with validation enforcing `YYYY` format (1900-2100)

## Testing

- ✅ `/api/countries/KEN` now returns 200 with valid JSON
- ✅ `/api/countries/USA` still works (no results)
- ✅ Other endpoints unaffected